### PR TITLE
ID 5bshce3qiky00p0: Add Augur to DeFi apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Awesome DeFi apps you can deploy on Akash
 
 - [Serum DEX UI](https://github.com/ovrclk/serum-on-akash)
 - [Uniswap](uniswap)
+- [Augur](augur)
 
 ### Blogging
 

--- a/augur/README.md
+++ b/augur/README.md
@@ -1,0 +1,5 @@
+# Augur
+
+From [the project site](https://github.com/AugurProject/augur):
+
+Augur is a decentralized oracle and peer to peer protocol for prediction markets.

--- a/augur/deploy.yaml
+++ b/augur/deploy.yaml
@@ -1,0 +1,39 @@
+---
+version: "2.0"
+
+services:
+  web:
+    image: augurproject/augur
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.1
+        memory:
+          size: 512Mi
+        storage:
+          size: 512Mi
+  placement:
+    westcoast:
+      attributes:
+        organization: ovrclk.com
+      signedBy:
+        anyOf:
+          - "akash1vz375dkt0c60annyp6mkzeejfq0qpyevhseu05"
+      pricing:
+        web: 
+          denom: uakt
+          amount: 1000
+
+deployment:
+  web:
+    westcoast:
+      profile: web
+      count: 1


### PR DESCRIPTION
Deployed: 15maavfe65e3j66safqh6lvfqs.provider2.akashdev.net
I'm getting SSL errors when I tried to navigate to it, so if you also see something like "Your connection is not private" from your browser, choose the "proceed anyway" option and you should be able to access the Augur app.

akash provider lease-status:
{
  "services": {
    "web": {
      "name": "web",
      "available": 1,
      "total": 1,
      "uris": [
        "15maavfe65e3j66safqh6lvfqs.provider2.akashdev.net"
      ],
      "observed-generation": 0,
      "replicas": 0,
      "updated-replicas": 0,
      "ready-replicas": 0,
      "available-replicas": 0
    }
  },
  "forwarded-ports": {}
}