### PR TITLE
ID 5bshce3qiky00p0: Add Jira to Project Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Awesome DeFi apps you can deploy on Akash
 
 - [Jenkins](jenkins)
 
+### Project Management
+- [Jira Software](jira)
+
 ### Tools
 - [DEGO Stats](dego-stats)
 - [authsteem](authsteem)

--- a/jira/README.md
+++ b/jira/README.md
@@ -1,0 +1,11 @@
+# Jira Software
+
+From [the official Docker Hub image page](https://hub.docker.com/r/atlassian/jira-software):
+
+Jira Software Data Center helps the world’s best agile teams plan, track, and release great software at scale.
+
+* Check out atlassian/jira-software on Docker Hub
+* Learn more about Jira Software: https://www.atlassian.com/software/jira
+
+The `deploy.yaml` uses the official Docker image to deploy a basic configuration of Jira Software on Akash.
+

--- a/jira/deploy.yaml
+++ b/jira/deploy.yaml
@@ -1,0 +1,39 @@
+---
+version: "2.0"
+
+services:
+  web:
+    image: atlassian/jira-software:latest
+    expose:
+      - port: 8080
+        as: 80
+        to:
+          - global: true
+
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.1
+        memory:
+          size: 512Mi
+        storage:
+          size: 1Gi
+  placement:
+    westcoast:
+      attributes:
+        organization: ovrclk.com
+      signedBy:
+        anyOf:
+          - "akash1vz375dkt0c60annyp6mkzeejfq0qpyevhseu05"
+      pricing:
+        web: 
+          denom: uakt
+          amount: 1000
+
+deployment:
+  web:
+    westcoast:
+      profile: web
+      count: 1


### PR DESCRIPTION
{
  "services": {
    "web": {
      "name": "web",
      "available": 1,
      "total": 1,
      "uris": [
        "pesmdc6ik5dqf273i0rjrhcs5g.provider1.akashdev.net"
      ],
      "observed-generation": 0,
      "replicas": 0,
      "updated-replicas": 0,
      "ready-replicas": 0,
      "available-replicas": 0
    }
  },
  "forwarded-ports": {}
}

I can verify the link above works, but it gets shut down after a a while, so you may get 404 by the time you see this. If you were to deploy this yourself, note that:

- Jira recommends a lot more resources than I'm specifying in the deploy yml, so once deployed, you're going to see 502 while it sets up.
- For me, after deploying it took around 6 minutes to go from 502 to seeing the Jira page.
- Jira show a progress bar to indicate it's setting up, and it'll take another 10-15 minutes from there.
- After some time, everything works and you can play around. In a previous test deployment using more 1GB RAM, 0.5 CPU, 1GB disk, If I don't touch it after some time though (an hour or so?), the deployment shuts itself down and I get 404, I suspect because of resource limits on the testnet. Might happen with this one too, we'll see.
-Anyways, pretty cool to see it work :)
