### PR TITLE
Fix indentation in moneroocean deploy.yaml

### DIFF
--- a/moneroocean/deploy.yaml
+++ b/moneroocean/deploy.yaml
@@ -22,12 +22,12 @@ profiles:
           size: 4Gi
         storage:
           size: 4Gi
-placement:
-  akash:
-    pricing:
-      moneroocean:
-        denom: uakt
-        amount: 25
+  placement:
+    akash:
+      pricing:
+        moneroocean:
+          denom: uakt
+          amount: 25
 deployment:
   moneroocean:
     akash:


### PR DESCRIPTION
The placement section was not inside the profiles in the yaml file. Added the missing indentation.