### PR TITLE
Update wordpress deployment example

### DIFF
--- a/wordpress/deploy.yaml
+++ b/wordpress/deploy.yaml
@@ -4,10 +4,27 @@ version: "2.0"
 services:
   wordpress:
     image: wordpress 
+    env:
+      - WORDPRESS_DB_HOST=db
+      - WORDPRESS_DB_USER=exampleuser
+      - WORDPRESS_DB_PASSWORD=examplepass
+      - WORDPRESS_DB_NAME=exampledb
     expose:
       - port: 80
         to:
           - global: true
+
+  db:
+    image: mysql:5.7
+    env:
+      - MYSQL_DATABASE=exampledb
+      - MYSQL_USER=exampleuser
+      - MYSQL_PASSWORD=examplepass
+      - MYSQL_RANDOM_ROOT_PASSWORD=1
+    expose:
+      - port: 3306
+        to:
+          - wordpress
 
 profiles:
   compute:
@@ -19,6 +36,14 @@ profiles:
           size: 1Gi
         storage:
           size: 2Gi
+    db:
+      resources:
+        cpu: 
+          units: 0.5
+        memory:
+          size: "256Mi"
+        storage: 
+          size: "1Gi"
   placement:
     akash:
       attributes:
@@ -35,4 +60,8 @@ deployment:
   wordpress:
     akash:
       profile: wordpress
+      count: 1
+  db:
+    akash:
+      profile: db
       count: 1


### PR DESCRIPTION
This was missing configuration for the required database server, which meant that whoever wanted to use this as an example of how to get a "more complex" application running on Akash would be presented with database errors.