### PR TITLE
fix minecraft to v1.17

### DIFF
--- a/minecraft/deploy.yaml
+++ b/minecraft/deploy.yaml
@@ -12,7 +12,7 @@ services:
     env:
       - FORCE_REDOWNLOAD=true
       - EULA=TRUE
-      - VERSION=LATEST
+      - VERSION=1.17
       - SERVER_NAME=AkashMinecraft
       - MEMORY=4G
       - MAX_PLAYERS=10


### PR DESCRIPTION
otherwise it fails with the following error:

web: Error: LinkageError occurred while loading main class net.minecraft.bundler.Main
web:     java.lang.UnsupportedClassVersionError: net/minecraft/bundler/Main has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 60.0
web: 2022-04-08T14:36:47.969Z    WARN    mc-server-runner    sub-process failed    {"exitCode": 1}

to update the image, the image source needs to be changed:

- https://github.com/slowriot/docker-minecraft-server/blob/master/Dockerfile#L1

it looks like adoptopenjdk:16-jre needs to be replaced with eclipse-temurin:17-jre (its successor) or similar.