### PR TITLE
default to eden chain spec

### DIFF
--- a/nodle-node/Dockerfile
+++ b/nodle-node/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu
 ENV PROFILE=release
 ENV MODE=release
 ENV NAME="akash.network"
-ENV CHAIN=main
+ENV CHAIN=eden
 ENV PRUNING=
 ENV STARTUP="--rpc-external --ws-external --rpc-cors all --wasm-execution compiled"
 

--- a/nodle-node/deploy.yaml
+++ b/nodle-node/deploy.yaml
@@ -26,10 +26,7 @@ services:
       - NAME="Akash Network" #Name of your Nodle node
         #Node name should not contain invalid chars such as '.' and '@'.
       - PRUNING= #Use archive to enable archival node
-      - CHAIN=main
-        #We specify which chain to sync with via --chain main, if you wanted to sync with our test 
-        #network you could replace it with --chain arcadia. When running a parachain collator 
-        #you will be able to use --chain eden.
+      - CHAIN=eden
       - STARTUP="--rpc-external --ws-external --wasm-execution compiled  --prometheus-external"
 profiles:
   compute:


### PR DESCRIPTION
The `nodle-parachain` binary no longer supports the `main` spec (moved to `nodle-chain`), this PR changes your config to sync the parachain instead of the soon to be deprecated solo chain.
