### PR TITLE
add uptime-kuma deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Awesome DeFi apps you can deploy on Akash
 - [KnowYourDeFi](knowyourdefi)
 - [Code-Server](code-server)
 - [Hashicorp Vault](hashicorp-vault)
+- [Uptime-Kuma](uptime-kuma)
 
 ### Network
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Awesome DeFi apps you can deploy on Akash
 - [KnowYourDeFi](knowyourdefi)
 - [Code-Server](code-server)
 - [Hashicorp Vault](hashicorp-vault)
-- [Uptime-Kuma](uptime-kuma)
+- [Uptime Kuma](uptime-kuma)
 
 ### Network
 

--- a/uptime-kuma/README.md
+++ b/uptime-kuma/README.md
@@ -1,0 +1,5 @@
+# Uptime Kuma
+
+From [Uptime-Kuma](https://github.com/louislam/uptime-kuma)
+
+It is a self-hosted monitoring tool like "Uptime Robot".

--- a/uptime-kuma/README.md
+++ b/uptime-kuma/README.md
@@ -3,3 +3,59 @@
 From [Uptime-Kuma](https://github.com/louislam/uptime-kuma)
 
 It is a self-hosted monitoring tool like "Uptime Robot".
+
+<img src="https://uptime.kuma.pet/img/dark.jpg" width="700" alt="" />
+
+## ⭐ Features
+
+* Monitoring uptime for HTTP(s) / TCP / HTTP(s) Keyword / Ping / DNS Record / Push / Steam Game Server / Docker Containers.
+* Fancy, Reactive, Fast UI/UX.
+* Notifications via Telegram, Discord, Gotify, Slack, Pushover, Email (SMTP), and [90+ notification services, click here for the full list](https://github.com/louislam/uptime-kuma/tree/master/src/components/notifications).
+* 20 second intervals.
+* [Multi Languages](https://github.com/louislam/uptime-kuma/tree/master/src/languages)
+* Multiple Status Pages
+* Map Status Page to Domain
+* Ping Chart
+* Certificate Info
+* Proxy Support
+* 2FA available
+## 🖼 More Screenshots
+
+Light Mode:
+
+<img src="https://uptime.kuma.pet/img/light.jpg" width="512" alt="" />
+
+Status Page:
+
+<img src="https://user-images.githubusercontent.com/1336778/134628766-a3fe0981-0926-4285-ab46-891a21c3e4cb.png" width="512" alt="" />
+
+Settings Page:
+
+<img src="https://louislam.net/uptimekuma/2.jpg" width="400" alt="" />
+
+Telegram Notification Sample:
+
+<img src="https://louislam.net/uptimekuma/3.jpg" width="400" alt="" />
+
+## Motivation
+
+* I was looking for a self-hosted monitoring tool like "Uptime Robot", but it is hard to find a suitable one. One of the close ones is statping. Unfortunately, it is not stable and no longer maintained.
+* Want to build a fancy UI.
+* Learn Vue 3 and vite.js.
+* Show the power of Bootstrap 5.
+* Try to use WebSocket with SPA instead of REST API.
+* Deploy my first Docker image to Docker Hub.
+
+If you love this project, please consider giving me a ⭐.
+
+## 🗣️ Discussion
+
+### Issues Page
+
+You can discuss or ask for help in [issues](https://github.com/louislam/uptime-kuma/issues).
+
+### Subreddit
+
+My Reddit account: [u/louislamlam](https://reddit.com/u/louislamlam).  
+You can mention me if you ask a question on Reddit.
+[r/Uptime kuma](https://www.reddit.com/r/UptimeKuma/)

--- a/uptime-kuma/deploy.yaml
+++ b/uptime-kuma/deploy.yaml
@@ -3,7 +3,7 @@ version: "2.0"
 
 services:
   uptime:
-    image: louislam/uptime-kuma:latest
+    image: louislam/uptime-kuma:1.18.0
     expose:
       - port: 3001
         as: 80
@@ -21,8 +21,6 @@ profiles:
           - size: 512Mi
   placement:
     akash:
-      attributes:
-        host: akash
       signedBy:
         anyOf:
           - "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63"

--- a/uptime-kuma/deploy.yaml
+++ b/uptime-kuma/deploy.yaml
@@ -1,0 +1,39 @@
+---
+version: "2.0"
+
+services:
+  uptime:
+    image: louislam/uptime-kuma:latest
+    expose:
+      - port: 3001
+        as: 80
+        to:
+          - global: true
+profiles:
+  compute:
+    uptime:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 128Mi
+        storage:
+          - size: 512Mi
+  placement:
+    akash:
+      attributes:
+        host: akash
+      signedBy:
+        anyOf:
+          - "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63"
+          - "akash18qa2a2ltfyvkyj0ggj3hkvuj6twzyumuaru9s4"        
+      pricing:
+        uptime: 
+          denom: uakt
+          amount: 10000
+
+deployment:
+  uptime:
+    akash:
+      profile: uptime
+      count: 1


### PR DESCRIPTION
This PR adds a deployment manifest for Uptime-Kuma, a self-hosted monitoring tool like "Uptime Robot".