### PR TITLE
add flame deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Awesome DeFi apps you can deploy on Akash
 - [Caddy](caddy)
 - [Grafana](grafana)
 - [IPFS](ipfs)
+- [Flame](flame)
 
 ### Machine Learning
 

--- a/flame/README.md
+++ b/flame/README.md
@@ -1,0 +1,5 @@
+# Flame
+
+From [Flame](https://github.com/pawelmalak/flame)
+
+Flame is self-hosted startpage for your server. Its design is inspired (heavily) by [SUI](https://github.com/jeroenpardon/sui). Flame is very easy to setup and use. With built-in editors, it allows you to setup your very own application hub in no time - no file editing necessary.

--- a/flame/README.md
+++ b/flame/README.md
@@ -3,3 +3,33 @@
 From [Flame](https://github.com/pawelmalak/flame)
 
 Flame is self-hosted startpage for your server. Its design is inspired (heavily) by [SUI](https://github.com/jeroenpardon/sui). Flame is very easy to setup and use. With built-in editors, it allows you to setup your very own application hub in no time - no file editing necessary.
+
+![](https://github.com/pawelmalak/flame/blob/446b4095f6bb06e0f878efb4ac1f990a5ae7d39c/.github/home.png)
+
+## Description
+
+Flame is self-hosted startpage for your server. Its design is inspired (heavily) by [SUI](https://github.com/jeroenpardon/sui). Flame is very easy to setup and use. With built-in editors, it allows you to setup your very own application hub in no time - no file editing necessary.
+
+## Functionality
+- 📝 Create, update, delete your applications and bookmarks directly from the app using built-in GUI editors
+- 📌 Pin your favourite items to the homescreen for quick and easy access
+- 🔍 Integrated search bar with local filtering, 11 web search providers and ability to add your own
+- 🔑 Authentication system to protect your settings, apps and bookmarks
+- 🔨 Dozens of options to customize Flame interface to your needs, including support for custom CSS, 15 built-in color themes and custom theme builder
+- ☀️ Weather widget with current temperature, cloud coverage and animated weather status
+- 🐳 Docker integration to automatically pick and add apps based on their labels
+
+### Search bar
+
+#### Searching
+
+The default search setting is to search through all your apps and bookmarks. If you want to search using specific search engine, you need to type your search query with selected prefix. For example, to search for "what is docker" using google search you would type: `/g what is docker`.
+
+For list of supported search engines, shortcuts and more about searching functionality visit [project wiki](https://github.com/pawelmalak/flame/wiki/Search-bar).
+
+### Setting up weather module
+
+1. Obtain API Key from [Weather API](https://www.weatherapi.com/pricing.aspx).
+   > Free plan allows for 1M calls per month. Flame is making less then 3K API calls per month.
+2. Get lat/long for your location. You can get them from [latlong.net](https://www.latlong.net/convert-address-to-lat-long.html).
+3. Enter and save data. Weather widget will now update and should be visible on Home page.

--- a/flame/deploy.yaml
+++ b/flame/deploy.yaml
@@ -1,0 +1,40 @@
+---
+    version: "2.0"
+    
+    services:
+      web:
+        image: pawelmalak/flame
+        expose:
+          - port: 5005
+            as: 80
+            to:
+              - global: true
+    
+    profiles:
+      compute:
+        web:
+          resources:
+            cpu:
+              units: 0.5
+            memory:
+              size: 128Mi
+            storage:
+              size: 64Mi
+      placement:
+        dcloud:
+          attributes:
+            host: akash
+          signedBy:
+            anyOf:
+              - "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63"
+              - "akash18qa2a2ltfyvkyj0ggj3hkvuj6twzyumuaru9s4"            
+          pricing:
+            web:
+              denom: uakt
+              amount: 10000
+    
+    deployment:
+      web:
+        dcloud:
+          profile: web
+          count: 1

--- a/flame/deploy.yaml
+++ b/flame/deploy.yaml
@@ -3,7 +3,7 @@
     
     services:
       web:
-        image: pawelmalak/flame
+        image: pawelmalak/flame:multiarch2.3.0
         expose:
           - port: 5005
             as: 80


### PR DESCRIPTION
This PR adds a deployment manifest for Flame, a self-hosted startpage / application dashboard.