### PR TITLE
feat: Add supabase deployment example

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ Awesome DeFi apps you can deploy on Akash
 ### Databases
 
 - [redis](redis)
+- [Supabase](supabase)
 
 ### Video Conferencing
 

--- a/subapase/README.md
+++ b/subapase/README.md
@@ -1,0 +1,128 @@
+# Supabase on Akash
+
+This template deploys [Supabase](https://supabase.com/), an open source Firebase alternative offering all the backend features developers need to build a product: PostgreSQL database, authentication, instant APIs, realtime subscriptions, and storage.
+
+## Features
+
+- PostgreSQL database
+- RESTful API with PostgREST
+- Authentication with GoTrue
+- Realtime subscriptions
+- File storage
+- Supabase Studio (Web UI)
+
+## Deployment
+
+### Prerequisites
+
+- Akash account with funds
+- Akash CLI installed and configured
+
+### Security Configuration (Important)
+
+⚠️ **Before deploying:** You must edit the `deploy.yaml` file to replace the placeholder values with your own secure keys and secrets:
+
+1. Generate a JWT secret (at least 32 characters) for these fields:
+   - `PGRST_JWT_SECRET`
+   - `GOTRUE_JWT_SECRET`
+   - `JWT_SECRET`
+
+   You can generate a secure random string with:
+   ```bash
+   openssl rand -base64 32
+   ```
+
+2. Generate JWT tokens for Supabase authentication:
+   - For `SUPABASE_ANON_KEY` and `ANON_KEY`: Create an anonymous role JWT
+   - For `SUPABASE_SERVICE_KEY` and `SERVICE_KEY`: Create a service role JWT
+   
+   **Important:** Both the anonymous and service tokens must be signed with the same `JWT_SECRET` you created in step 1.
+   
+   You can use the [jwt.io](https://jwt.io/) website with your JWT secret to create these tokens with the appropriate payloads.
+
+3. Consider changing the default database credentials for production use.
+
+### Deploying on Akash
+
+1. Create a deployment with the provided SDL:
+
+```bash
+provider-services tx deployment create deploy.yaml --from <YOUR_KEY_NAME>
+```
+
+2. List deployments and find your deployment ID:
+
+```bash
+provider-services query deployment list --owner <YOUR_AKASH_ADDRESS>
+```
+
+3. Create a lease:
+
+```bash
+provider-services tx market lease create --dseq <DEPLOYMENT_ID> --provider <PROVIDER_ADDRESS> --from <YOUR_KEY_NAME>
+```
+
+4. Send manifest:
+
+```bash
+provider-services send-manifest deploy.yaml --dseq <DEPLOYMENT_ID> --provider <PROVIDER_ADDRESS> --from <YOUR_KEY_NAME>
+```
+
+5. Get lease status (includes your Supabase Studio URL):
+
+```bash
+provider-services lease-status --dseq <DEPLOYMENT_ID> --provider <PROVIDER_ADDRESS> --from <YOUR_KEY_NAME>
+```
+
+### Post-Deployment Configuration (Important)
+
+After deployment, you must update the following environment variables in your `deploy.yaml` file with your actual Akash ingress URL, then redeploy:
+
+- `PUBLIC_URL`: Set to `https://<deployment-id>.ingress.akash.network`
+- `SUPABASE_PUBLIC_URL`: Set to `https://<deployment-id>.ingress.akash.network`
+- `API_EXTERNAL_URL`: Set to `https://<deployment-id>.ingress.akash.network`
+- `GOTRUE_SITE_URL`: Set to `https://<deployment-id>.ingress.akash.network`
+
+Without this step, authentication and other features may not work properly.
+
+## Access and Configuration
+
+Once deployed, you can access the Supabase Studio at:
+
+```
+https://<deployment-id>.ingress.akash.network
+```
+
+For example, if your deployment ID is `123456`, the URL would be:
+```
+https://123456.ingress.akash.network
+```
+
+You'll need to use the keys you configured in the deployment YAML for authentication.
+
+## Data Persistence
+
+This deployment includes persistent storage for:
+
+- PostgreSQL data at `/var/lib/postgresql/data`
+- Storage API files at `/var/lib/storage`
+
+Your data should persist across restarts as long as the lease is maintained.
+
+## Connecting to Your Supabase Instance
+
+Once Supabase is running, you can use the Studio web interface to:
+
+1. Create and manage database tables
+2. Set up authentication providers
+3. Create API keys
+4. Configure storage buckets
+5. View realtime logs and more
+
+For client applications, use the public URL and anon key to connect using the [Supabase client libraries](https://github.com/supabase/supabase-js).
+
+## Additional Resources
+
+- [Supabase Documentation](https://supabase.com/docs)
+- [Supabase GitHub](https://github.com/supabase/supabase)
+- [Akash Network Documentation](https://akash.network/docs/)

--- a/subapase/config.json
+++ b/subapase/config.json
@@ -1,0 +1,18 @@
+{
+  "logo": {
+    "url": "https://supabase.com/dashboard/img/supabase-logo.svg"
+  },
+  "display": {
+    "name": "Supabase",
+    "description": "Open source Firebase alternative with all the backend features developers need: PostgreSQL database, authentication, instant APIs, and realtime subscriptions."
+  },
+  "tags": [
+    "database",
+    "api",
+    "backend",
+    "postgresql",
+    "authentication",
+    "storage"
+  ]
+}
+

--- a/subapase/deploy.yaml
+++ b/subapase/deploy.yaml
@@ -1,0 +1,268 @@
+---
+version: "2.0"
+
+services:
+  db:
+    image: supabase/postgres:15.1.0.147
+    expose:
+      - port: 5432
+        to:
+          - service: studio
+          - service: api
+          - service: gotrue
+          - service: storage
+          - service: meta
+    command:
+      - /bin/sh
+      - -c
+      - |
+        chown -R postgres:postgres /var/lib/postgresql/data || true
+        chmod 700 /var/lib/postgresql/data || true
+        exec docker-entrypoint.sh postgres -c listen_addresses='*'
+    env:
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=${POSTGRES_DB}
+      - PGDATA=/var/lib/postgresql/data/pgdata
+    params:
+      storage:
+        data:
+          mount: /var/lib/postgresql/data
+          readOnly: false
+
+  api:
+    image: postgrest/postgrest:v12.2.12
+    depends_on:
+      - db
+    expose:
+      - port: 3000
+        to:
+          - service: studio
+          - service: gotrue
+          - service: storage
+          - service: meta
+    env:
+      - PGRST_DB_URI=postgres://postgres:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      - PGRST_DB_SCHEMAS=public
+      - PGRST_DB_ANON_ROLE=anon
+      - PGRST_JWT_SECRET=${JWT_SECRET}
+      - PGRST_LOG_LEVEL=info
+
+  studio:
+    image: supabase/studio:20241029-46e1e40
+    depends_on:
+      - db
+      - api
+      - gotrue
+      - storage
+      - meta
+    expose:
+      - port: 3000
+        as: 80
+        to:
+          - global: true
+    env:
+      - STUDIO_PG_META_URL=http://meta:8080
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - SUPABASE_URL=http://api:3000
+      - SUPABASE_PUBLIC_URL=${PUBLIC_URL}
+      - SUPABASE_ANON_KEY=${ANON_KEY}
+      - SUPABASE_SERVICE_KEY=${SERVICE_KEY}
+
+  gotrue:
+    image: supabase/gotrue:v2.180.0
+    depends_on:
+      - db
+    expose:
+      - port: 9999
+        to:
+          - service: studio
+    command:
+      - /bin/sh
+      - -c
+      - |
+        echo "Waiting for database initialization..."
+        sleep 120
+        echo "Starting GoTrue..."
+        exec gotrue
+    env:
+      - API_EXTERNAL_URL=${PUBLIC_URL}
+      - GOTRUE_API_HOST=0.0.0.0
+      - GOTRUE_API_PORT=9999
+      - GOTRUE_DB_DRIVER=postgres
+      - GOTRUE_DB_DATABASE_URL=postgres://postgres:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      - GOTRUE_SITE_URL=${PUBLIC_URL}
+      - GOTRUE_URI_ALLOW_LIST=${ALLOWED_REDIRECT_URLS}
+      - GOTRUE_DISABLE_SIGNUP=${DISABLE_SIGNUP}
+      - GOTRUE_JWT_SECRET=${JWT_SECRET}
+      - GOTRUE_JWT_EXP=3600
+      - GOTRUE_JWT_DEFAULT_GROUP_NAME=authenticated
+      - GOTRUE_EXTERNAL_EMAIL_ENABLED=false
+      - GOTRUE_MAILER_AUTOCONFIRM=true
+      - GOTRUE_SMS_AUTOCONFIRM=true
+
+  storage:
+    image: supabase/storage-api:v1.24.7
+    depends_on:
+      - db
+      - api
+    expose:
+      - port: 5000
+        to:
+          - service: studio
+    command:
+      - /bin/sh
+      - -c
+      - |
+        echo "Waiting for database and API..."
+        sleep 130
+        echo "Starting Storage API..."
+        exec node dist/app.js
+    env:
+      - ANON_KEY=${ANON_KEY}
+      - SERVICE_KEY=${SERVICE_KEY}
+      - POSTGREST_URL=http://api:3000
+      - PGRST_JWT_SECRET=${JWT_SECRET}
+      - DATABASE_URL=postgres://postgres:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      - FILE_SIZE_LIMIT=50000000
+      - STORAGE_BACKEND=file
+      - FILE_STORAGE_BACKEND_PATH=/var/lib/storage
+      - TENANT_ID=stub
+    params:
+      storage:
+        storage-files:
+          mount: /var/lib/storage
+          readOnly: false
+
+  meta:
+    image: supabase/postgres-meta:v0.89.3
+    depends_on:
+      - db
+    expose:
+      - port: 8080
+        to:
+          - service: studio
+    command:
+      - /bin/sh
+      - -c
+      - |
+        echo "Waiting for database..."
+        sleep 110
+        echo "Starting Meta API..."
+        exec node dist/server/app.js
+    env:
+      - PG_META_PORT=8080
+      - PG_META_DB_HOST=db
+      - PG_META_DB_PASSWORD=${POSTGRES_PASSWORD}
+      - PG_META_DB_PORT=5432
+      - PG_META_DB_NAME=${POSTGRES_DB}
+      - PG_META_DB_USER=postgres
+
+profiles:
+  compute:
+    db:
+      resources:
+        cpu:
+          units: 1
+        memory:
+          size: 2Gi
+        storage:
+          - size: 1Gi
+          - name: data
+            size: 10Gi
+            attributes:
+              persistent: true
+              class: beta3
+    api:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          - size: 1Gi
+    studio:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          - size: 1Gi
+    gotrue:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          - size: 1Gi
+    storage:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          - size: 1Gi
+          - name: storage-files
+            size: 10Gi
+            attributes:
+              persistent: true
+              class: beta3
+    meta:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          - size: 1Gi
+
+  placement:
+    akash:
+      pricing:
+        db:
+          denom: uakt
+          amount: 10000
+        api:
+          denom: uakt
+          amount: 5000
+        studio:
+          denom: uakt
+          amount: 5000
+        gotrue:
+          denom: uakt
+          amount: 5000
+        storage:
+          denom: uakt
+          amount: 5000
+        meta:
+          denom: uakt
+          amount: 5000
+
+deployment:
+  db:
+    akash:
+      profile: db
+      count: 1
+  api:
+    akash:
+      profile: api
+      count: 1
+  studio:
+    akash:
+      profile: studio
+      count: 1
+  gotrue:
+    akash:
+      profile: gotrue
+      count: 1
+  storage:
+    akash:
+      profile: storage
+      count: 1
+  meta:
+    akash:
+      profile: meta
+      count: 1


### PR DESCRIPTION
- Add deployment example for Supabase, the open source Firebase alternative:
- Create supabase folder with deploy.yaml for PostgreSQL, API, Studio
- Add README.md with instructions for deploying and configuring
- Include config.json with logo and metadata
- Update main README.md to add Supabase in the Databases section

This allows Akash users to easily deploy Supabase on their providers.

Closes #693 