### PR TITLE
Add Hermes Agent to AI - CPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ To add a new template/resource:
 - [Faster Whisper](faster-whisper-cpu)
 - [Flowise](flowise)
 - [Eliza AI Agent](Elizaos-ai_Agents)
+- [Hermes Agent](hermes-agent)
 - [InvokeAI](invoke-ai-cpu)
 - [Langflow](langflow)
 - [Morpheus Lumerin Node](morpheus-lumerin-node)

--- a/hermes-agent/README.md
+++ b/hermes-agent/README.md
@@ -1,12 +1,12 @@
 # Hermes Agent on Akash Console
 
-This template deploys [Hermes Agent](https://github.com/NousResearch/hermes-agent) on Akash as an SSH-first workspace with persistent storage.
+This template deploys [Hermes Agent](https://github.com/NousResearch/hermes-agent) on Akash as a persistent remote workspace.
 
-Unlike the OpenClaw template, Hermes does not require a dedicated web setup UI. The Akash-friendly pattern is:
+It now supports a hybrid flow:
 
-1. Deploy a container with SSH access and a persistent volume.
-2. Bootstrap Hermes from the official GitHub repository on first boot.
-3. SSH into the instance and run `hermes-akash setup` (CLI) or `hermes-akash gateway setup` (Telegram/Discord/etc.).
+1. SSH always remains available on port `22`.
+2. If you set only the minimal Telegram variables, Hermes auto-configures a default Telegram home channel and starts the gateway automatically.
+3. If you leave those variables empty, the deployment behaves like a plain SSH workspace and you can finish setup manually later.
 
 ## What this template does
 
@@ -21,32 +21,50 @@ Unlike the OpenClaw template, Hermes does not require a dedicated web setup UI. 
   - `web`
 - Persists `HERMES_HOME` at `/workspace/hermes-home`.
 - Creates a helper command: `hermes-akash`.
+- Optionally bootstraps a minimal Telegram config on first start.
+- Optionally auto-starts `hermes gateway` when minimal Telegram env vars are present.
 
-## Required configuration
+## Minimal zero-SSH Telegram setup
 
-Before deploying, replace these environment values in Akash Console:
+Set these in Akash Console:
 
-- `SSH_PUBKEY` — your SSH public key (required).
-- `HERMES_REF` — optional Git ref to deploy (`main`, a tag, or a release branch).
+- `TELEGRAM_BOT_TOKEN` — your bot token
+- `TELEGRAM_HOME_CHANNEL` — your Telegram user/chat ID
 
-## Deploy steps
+Optional display name:
 
-1. Open the template in Akash Console.
-2. Set `SSH_PUBKEY` to your public key.
-3. Optionally pin `HERMES_REF` to a release tag instead of `main`.
-4. Deploy the SDL.
-5. Wait for the container to finish the first-boot bootstrap.
-   - First boot can take several minutes because Ubuntu packages and Python dependencies are installed inside the container.
-6. SSH into the instance.
-7. Run one of:
+- `TELEGRAM_HOME_CHANNEL_NAME=Home`
+
+With just those values set, the container will:
+
+- keep SSH available
+- write `TELEGRAM_BOT_TOKEN` into `/workspace/hermes-home/.env`
+- write a default Telegram `home_channel` into `/workspace/hermes-home/config.yaml`
+- start `hermes gateway` automatically
+
+No topics or advanced Telegram settings are prefilled. Those can be configured later from inside Hermes if you want.
+
+## Optional model/provider env vars
+
+You can also prefill the runtime model selection:
+
+- `HERMES_MODEL` — for example `openai/gpt-5.4` or `anthropic/claude-sonnet-4-6`
+- `HERMES_PROVIDER` — for example `openrouter`, `anthropic`, `openai-codex`, `auto`
+
+And whichever provider keys you use, for example:
+
+- `OPENROUTER_API_KEY`
+- `OPENAI_API_KEY`
+- `ANTHROPIC_API_KEY`
+
+## SSH-first fallback mode
+
+If `TELEGRAM_BOT_TOKEN` or `TELEGRAM_HOME_CHANNEL` is left empty, the container does not auto-start the gateway. It behaves like a normal SSH workspace instead.
+
+After SSH login, you can still run:
 
 ```bash
 hermes-akash setup
-```
-
-For messaging gateway usage:
-
-```bash
 hermes-akash gateway setup
 hermes-akash gateway start
 ```
@@ -59,25 +77,22 @@ hermes-akash gateway start
 - Main config: `/workspace/hermes-home/config.yaml`
 - Sessions, skills, memories, logs: under `/workspace/hermes-home/`
 
-## Typical Telegram bot flow
+## Notes about the default Telegram config
 
-After SSH login:
+The auto-generated config is intentionally minimal:
 
-```bash
-hermes-akash gateway setup
-# add Telegram token + provider keys when prompted
-hermes-akash gateway start
-```
+- Telegram is enabled
+- a default `home_channel` is set from `TELEGRAM_HOME_CHANNEL`
+- `reply_to_mode` defaults to `first`
+- no topics are preconfigured
+- no advanced mention / reaction / free-response settings are forced
 
-Once the gateway is running, Hermes can answer in Telegram while the state stays on the Akash persistent volume.
+This keeps the Akash template simple while still giving you a working bot immediately after deploy.
 
-## Notes and caveats
+## First boot behavior
 
-- This template is SSH-based because Hermes is primarily a CLI + messaging agent runtime, not a fixed web app.
-- The default resources are sized for a general-purpose remote assistant, not GPU inference. Hermes is designed to call external model providers (OpenAI, Anthropic, OpenRouter, etc.).
-- If you want a reproducible production rollout, set `HERMES_REF` to a tagged release.
-- If you need browser automation with Playwright or additional system packages, install them after SSH login based on your workflow.
+On the first boot, if the Telegram autostart env vars are present, the template writes the default Telegram config once and drops a marker file in the persistent volume so later restarts do not overwrite your manual config edits.
 
 ## Why this differs from OpenClaw
 
-The OpenClaw Akash template exposes a setup UI over HTTP and uses a prebuilt application image. Hermes currently fits Akash better as a persistent remote agent workspace: install once, configure through SSH, then keep using Telegram/Discord/CLI as the interface.
+The OpenClaw Akash template exposes a setup UI over HTTP and stores configuration through that UI. Hermes is better suited to an SSH + messaging workflow, so this template uses environment-driven bootstrap for the minimal path and still leaves the full SSH workflow available.

--- a/hermes-agent/README.md
+++ b/hermes-agent/README.md
@@ -61,6 +61,17 @@ And whichever provider keys you use, for example:
 
 If `TELEGRAM_BOT_TOKEN` or `TELEGRAM_HOME_CHANNEL` is left empty, the container does not auto-start the gateway. It behaves like a normal SSH workspace instead.
 
+## OAuth limitation
+
+The environment-variable bootstrap path is best for API-key based providers such as OpenRouter, OpenAI API, or Anthropic API.
+
+Providers that require an interactive OAuth or device-code login flow — for example `openai-codex` / ChatGPT-style login — are not fully bootstrapable from `deploy.yaml` alone today. They still need a post-deploy login step so Hermes can obtain and persist refreshable OAuth credentials in its auth store / credential pool.
+
+In other words:
+
+- API key providers: good fit for Akash env vars
+- OAuth-only / device-code providers: still require interactive login after deploy
+
 After SSH login, you can still run:
 
 ```bash

--- a/hermes-agent/README.md
+++ b/hermes-agent/README.md
@@ -1,0 +1,83 @@
+# Hermes Agent on Akash Console
+
+This template deploys [Hermes Agent](https://github.com/NousResearch/hermes-agent) on Akash as an SSH-first workspace with persistent storage.
+
+Unlike the OpenClaw template, Hermes does not require a dedicated web setup UI. The Akash-friendly pattern is:
+
+1. Deploy a container with SSH access and a persistent volume.
+2. Bootstrap Hermes from the official GitHub repository on first boot.
+3. SSH into the instance and run `hermes-akash setup` (CLI) or `hermes-akash gateway setup` (Telegram/Discord/etc.).
+
+## What this template does
+
+- Exposes port `22` for SSH access.
+- Clones `NousResearch/hermes-agent` into `/workspace/hermes-agent`.
+- Installs Hermes in a local virtualenv with the extras most useful for remote agent hosting:
+  - `messaging`
+  - `cron`
+  - `pty`
+  - `mcp`
+  - `honcho`
+  - `web`
+- Persists `HERMES_HOME` at `/workspace/hermes-home`.
+- Creates a helper command: `hermes-akash`.
+
+## Required configuration
+
+Before deploying, replace these environment values in Akash Console:
+
+- `SSH_PUBKEY` — your SSH public key (required).
+- `HERMES_REF` — optional Git ref to deploy (`main`, a tag, or a release branch).
+
+## Deploy steps
+
+1. Open the template in Akash Console.
+2. Set `SSH_PUBKEY` to your public key.
+3. Optionally pin `HERMES_REF` to a release tag instead of `main`.
+4. Deploy the SDL.
+5. Wait for the container to finish the first-boot bootstrap.
+   - First boot can take several minutes because Ubuntu packages and Python dependencies are installed inside the container.
+6. SSH into the instance.
+7. Run one of:
+
+```bash
+hermes-akash setup
+```
+
+For messaging gateway usage:
+
+```bash
+hermes-akash gateway setup
+hermes-akash gateway start
+```
+
+## Persistent paths
+
+- Hermes repo: `/workspace/hermes-agent`
+- Hermes profile home: `/workspace/hermes-home`
+- Provider keys / tokens: `/workspace/hermes-home/.env`
+- Main config: `/workspace/hermes-home/config.yaml`
+- Sessions, skills, memories, logs: under `/workspace/hermes-home/`
+
+## Typical Telegram bot flow
+
+After SSH login:
+
+```bash
+hermes-akash gateway setup
+# add Telegram token + provider keys when prompted
+hermes-akash gateway start
+```
+
+Once the gateway is running, Hermes can answer in Telegram while the state stays on the Akash persistent volume.
+
+## Notes and caveats
+
+- This template is SSH-based because Hermes is primarily a CLI + messaging agent runtime, not a fixed web app.
+- The default resources are sized for a general-purpose remote assistant, not GPU inference. Hermes is designed to call external model providers (OpenAI, Anthropic, OpenRouter, etc.).
+- If you want a reproducible production rollout, set `HERMES_REF` to a tagged release.
+- If you need browser automation with Playwright or additional system packages, install them after SSH login based on your workflow.
+
+## Why this differs from OpenClaw
+
+The OpenClaw Akash template exposes a setup UI over HTTP and uses a prebuilt application image. Hermes currently fits Akash better as a persistent remote agent workspace: install once, configure through SSH, then keep using Telegram/Discord/CLI as the interface.

--- a/hermes-agent/config.json
+++ b/hermes-agent/config.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../config.schema.json",
+  "ssh": true,
+  "logoUrl": "https://raw.githubusercontent.com/NousResearch/hermes-agent/main/assets/banner.png"
+}

--- a/hermes-agent/deploy.yaml
+++ b/hermes-agent/deploy.yaml
@@ -1,0 +1,98 @@
+---
+version: "2.0"
+services:
+  hermes-agent:
+    image: ubuntu:24.04
+    expose:
+      - port: 22
+        as: 22
+        to:
+          - global: true
+    command:
+      - bash
+      - "-lc"
+    args:
+      - |
+        set -euo pipefail
+        export DEBIAN_FRONTEND=noninteractive
+
+        apt-get update
+        apt-get install -y --no-install-recommends ca-certificates curl ffmpeg git openssh-server procps python3 python3-dev python3-venv ripgrep build-essential gcc libffi-dev
+        rm -rf /var/lib/apt/lists/*
+
+        mkdir -p /run/sshd /workspace/hermes-home/home
+        mkdir -p /root/.ssh
+        chmod 700 /root/.ssh
+        if [ -n "${SSH_PUBKEY:-}" ]; then
+          printf "%s\n" "$SSH_PUBKEY" > /root/.ssh/authorized_keys
+          chmod 600 /root/.ssh/authorized_keys
+        fi
+
+        if [ ! -d /workspace/hermes-agent/.git ]; then
+          git clone --depth 1 --branch "$HERMES_REF" https://github.com/NousResearch/hermes-agent.git /workspace/hermes-agent
+        else
+          cd /workspace/hermes-agent
+          git fetch --depth 1 origin "$HERMES_REF"
+          git checkout FETCH_HEAD
+        fi
+
+        if [ ! -x /root/.local/bin/uv ]; then
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+        fi
+        export PATH="/root/.local/bin:$PATH"
+
+        cd /workspace/hermes-agent
+        if [ ! -d .venv ]; then
+          uv venv
+        fi
+        . .venv/bin/activate
+        uv pip install --upgrade pip setuptools wheel
+        uv pip install -e ".[messaging,cron,pty,mcp,honcho,web]"
+
+        if [ ! -f /workspace/hermes-home/.env ]; then
+          cp .env.example /workspace/hermes-home/.env
+        fi
+        if [ ! -f /workspace/hermes-home/config.yaml ]; then
+          cp cli-config.yaml.example /workspace/hermes-home/config.yaml
+        fi
+
+        printf '%s\n' '#!/usr/bin/env bash' 'export HERMES_HOME=/workspace/hermes-home' 'export HOME=/workspace/hermes-home/home' 'export PATH="/root/.local/bin:/workspace/hermes-agent/.venv/bin:$PATH"' 'cd /workspace/hermes-agent' 'exec hermes "$@"' > /usr/local/bin/hermes-akash
+        chmod +x /usr/local/bin/hermes-akash
+
+        printf '%s\n' 'Hermes Agent is installed.' '' 'Persistent state:' '  HERMES_HOME=/workspace/hermes-home' '' 'Quick start after SSH:' '  hermes-akash setup' '  hermes-akash gateway setup' '  hermes-akash gateway start' > /etc/motd
+
+        /usr/sbin/sshd -D -e
+    env:
+      - SSH_PUBKEY=YOUR_SSH_PUBLIC_KEY
+      - HERMES_REF=main
+    params:
+      storage:
+        data:
+          mount: /workspace
+          readOnly: false
+profiles:
+  compute:
+    hermes-agent:
+      resources:
+        cpu:
+          units: 4
+        memory:
+          size: 8Gi
+        storage:
+          - size: 8Gi
+          - name: data
+            size: 20Gi
+            attributes:
+              persistent: true
+              class: beta3
+  placement:
+    akash:
+      pricing:
+        hermes-agent:
+          denom: uact
+          amount: 20000
+deployment:
+  hermes-agent:
+    akash:
+      profile: hermes-agent
+      count: 1

--- a/hermes-agent/deploy.yaml
+++ b/hermes-agent/deploy.yaml
@@ -56,15 +56,74 @@ services:
           cp cli-config.yaml.example /workspace/hermes-home/config.yaml
         fi
 
+        python3 - <<'PY'
+        import os
+        from pathlib import Path
+        import yaml
+
+        home = Path('/workspace/hermes-home')
+        env_path = home / '.env'
+        config_path = home / 'config.yaml'
+        marker_path = home / '.akash-telegram-autoconfigured'
+
+        telegram_token = os.getenv('TELEGRAM_BOT_TOKEN', '').strip()
+        telegram_home = os.getenv('TELEGRAM_HOME_CHANNEL', '').strip()
+        home_name = os.getenv('TELEGRAM_HOME_CHANNEL_NAME', 'Home').strip() or 'Home'
+        model_default = os.getenv('HERMES_MODEL', '').strip()
+        model_provider = os.getenv('HERMES_PROVIDER', '').strip()
+
+        if telegram_token:
+            existing = env_path.read_text(encoding='utf-8') if env_path.exists() else ''
+            additions = []
+            if 'TELEGRAM_BOT_TOKEN=' not in existing:
+                additions.append(f'TELEGRAM_BOT_TOKEN={telegram_token}')
+            if additions:
+                prefix = '' if not existing or existing.endswith('\n') else '\n'
+                env_path.write_text(existing + prefix + '\n'.join(additions) + '\n', encoding='utf-8')
+
+        if telegram_token and telegram_home and not marker_path.exists():
+            cfg = yaml.safe_load(config_path.read_text(encoding='utf-8')) or {}
+            platforms = cfg.setdefault('platforms', {})
+            telegram = platforms.setdefault('telegram', {})
+            telegram['enabled'] = True
+            telegram['reply_to_mode'] = telegram.get('reply_to_mode', 'first')
+            telegram['home_channel'] = {
+                'platform': 'telegram',
+                'chat_id': str(telegram_home),
+                'name': home_name,
+            }
+            cfg.setdefault('telegram', {})
+            if model_default:
+                cfg.setdefault('model', {})['default'] = model_default
+            if model_provider:
+                cfg.setdefault('model', {})['provider'] = model_provider
+            config_path.write_text(yaml.safe_dump(cfg, sort_keys=False, allow_unicode=True), encoding='utf-8')
+            marker_path.write_text('configured\n', encoding='utf-8')
+        PY
+
         printf '%s\n' '#!/usr/bin/env bash' 'export HERMES_HOME=/workspace/hermes-home' 'export HOME=/workspace/hermes-home/home' 'export PATH="/root/.local/bin:/workspace/hermes-agent/.venv/bin:$PATH"' 'cd /workspace/hermes-agent' 'exec hermes "$@"' > /usr/local/bin/hermes-akash
         chmod +x /usr/local/bin/hermes-akash
 
-        printf '%s\n' 'Hermes Agent is installed.' '' 'Persistent state:' '  HERMES_HOME=/workspace/hermes-home' '' 'Quick start after SSH:' '  hermes-akash setup' '  hermes-akash gateway setup' '  hermes-akash gateway start' > /etc/motd
+        printf '%s\n' 'Hermes Agent is installed.' '' 'Persistent state:' '  HERMES_HOME=/workspace/hermes-home' '' 'Quick start after SSH:' '  hermes-akash setup' '  hermes-akash gateway setup' '  hermes-akash gateway start' '' 'Hybrid autostart:' '  If TELEGRAM_BOT_TOKEN and TELEGRAM_HOME_CHANNEL are set,' '  Hermes will auto-configure Telegram and start the gateway.' > /etc/motd
+
+        if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_HOME_CHANNEL:-}" ]; then
+          echo 'Starting sshd in background and Hermes gateway in foreground...'
+          /usr/sbin/sshd -D -e &
+          exec hermes-akash gateway start
+        fi
 
         /usr/sbin/sshd -D -e
     env:
       - SSH_PUBKEY=YOUR_SSH_PUBLIC_KEY
       - HERMES_REF=main
+      - TELEGRAM_BOT_TOKEN=
+      - TELEGRAM_HOME_CHANNEL=
+      - TELEGRAM_HOME_CHANNEL_NAME=Home
+      - HERMES_MODEL=
+      - HERMES_PROVIDER=
+      - OPENROUTER_API_KEY=
+      - OPENAI_API_KEY=
+      - ANTHROPIC_API_KEY=
     params:
       storage:
         data:


### PR DESCRIPTION
## Summary
- add a new `hermes-agent` Akash Console template
- document the SSH-first deployment flow for Hermes Agent
- update the AI - CPU section in the root README

## Notes
- Hermes is modeled after the existing OpenClaw contribution, but uses an SSH-based bootstrap flow because Hermes is primarily a CLI + messaging agent runtime rather than a fixed web setup app.
- The template persists `HERMES_HOME` on Akash storage and bootstraps Hermes from the official repository on first start.