### PR TITLE
Add Gemma 3 4B to AI - GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ To add a new template/resource:
 - [Flan-T5 XXL](flan-t5-xxl)
 - [FLock Validator](FLock-validator)
 - [FLock-Training-Node](FLock-training-node)
+- [Gemma 3 4B](gemma3-4b)
 - [Gensyn RL Swarm](gensyn-rl-swarm)
 - [GPT-Neo](gpt-neo)
 - [GPUStack](gpustack)

--- a/gemma3-4b/README.md
+++ b/gemma3-4b/README.md
@@ -1,0 +1,49 @@
+# Gemma 3 4B
+
+[![Deploy on Akash](https://raw.githubusercontent.com/akash-network/console/refs/heads/main/apps/deploy-web/public/images/deploy-with-akash-btn.svg)](https://console.akash.network/new-deployment?step=edit-deployment&templateId=akash-network-awesome-akash-gemma3-4b)
+
+Deploy Google's `gemma3:4b` on Akash with [Ollama](https://ollama.com) and expose the Ollama API on port `11434` (OpenAI-compatible at `/v1/chat/completions`).
+
+## Model
+
+- Ollama model tag: `gemma3:4b`
+- Upstream: [google/gemma-3-4b-it](https://huggingface.co/google/gemma-3-4b-it)
+- Size: ~3.3 GB (Q4_0 GGUF)
+- Runtime: `ollama/ollama:0.13.4`
+- API endpoints:
+  - Native Ollama: `http://<your-akash-uri>:11434/api/generate`
+  - OpenAI-compatible: `http://<your-akash-uri>:11434/v1/chat/completions`
+
+## Why this template
+
+Gemma 3 4B is in the sweet spot for low-cost Akash inference: small enough to fit on entry-level GPUs (or run on CPU), useful enough for agent workflows, JSON extraction, summarisation, and routing tasks. Ollama's built-in OpenAI-compatible endpoint lets you point any OpenAI SDK at this deployment with no code changes.
+
+## Deployment
+
+The included SDL uses:
+
+- `1` NVIDIA GPU
+- `4` vCPU
+- `16Gi` RAM
+- `50Gi` storage
+
+Gemma 3 4B runs comfortably on consumer GPUs (e.g. RTX 2070 8GB, RTX 3060 12GB). Any Akash provider offering a single NVIDIA GPU with ≥6GB VRAM is sufficient.
+
+The deployment runs:
+
+```shell
+ollama serve & while ! ollama pull gemma3:4b; do sleep 2.5; done
+ollama list
+pkill ollama
+ollama serve
+```
+
+(pull-then-restart pattern ensures the model is in the blob cache before serving.)
+
+## Customising the model
+
+To deploy a different Ollama model, change the `MODEL` env var in `deploy.yaml` (e.g. `gemma3:12b`, `gemma3:27b`, `qwen2.5:7b`). Adjust `memory`, `storage`, and GPU VRAM accordingly.
+
+## Files
+
+- [deploy.yaml](deploy.yaml)

--- a/gemma3-4b/deploy.yaml
+++ b/gemma3-4b/deploy.yaml
@@ -1,0 +1,53 @@
+---
+version: "2.0"
+services:
+  gemma3:
+    image: ollama/ollama:0.13.4
+    expose:
+      - port: 11434
+        as: 11434
+        to:
+          - global: true
+    env:
+      - MODEL=gemma3:4b
+    command:
+      - /bin/sh
+      - -c
+      - |
+        ollama serve &
+        while ! ollama pull ${MODEL}; do
+          echo "Waiting for ollama pull to succeed..."
+          sleep 2.5
+        done
+        ollama list
+        pkill ollama
+        ollama serve
+profiles:
+  compute:
+    gemma3:
+      resources:
+        cpu:
+          units: 4
+        memory:
+          size: 16Gi
+        storage:
+          size: 50Gi
+        gpu:
+          units: 1
+          attributes:
+            vendor:
+              nvidia:
+  placement:
+    akash:
+      signedBy:
+        anyOf:
+          - "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63"
+      pricing:
+        gemma3:
+          denom: uact
+          amount: 10000
+deployment:
+  gemma3:
+    akash:
+      profile: gemma3
+      count: 1


### PR DESCRIPTION
## Summary

Adds a deployment template for Google's `gemma3:4b` — a small, high-quality model that sits in the sweet spot for low-cost Akash inference.

- **Model:** `gemma3:4b` (~3.3 GB Q4_0 GGUF)
- **Runtime:** `ollama/ollama:0.13.4` (exposes both native Ollama API and OpenAI-compatible endpoint at `/v1`)
- **Resources:** 4 vCPU, 16 Gi RAM, 50 Gi storage, 1 NVIDIA GPU
- **Works on:** any provider offering a single NVIDIA GPU with ≥6 GB VRAM (RTX 2070, 3060, etc.)

## Why

The existing `ollama-gpu` template has a generic 28 Gi RAM / 100 Gi storage profile that over-provisions for a 4 B model and pushes users toward larger/more expensive providers than needed. Giving Gemma 3 4B its own right-sized folder:

- Makes it discoverable in the Console gallery
- Gives users a deploy-as-is template for agent workloads, JSON extraction, summarisation, routing
- Closes an obvious gap (DeepSeek-R1 distills, several Qwen sizes, multiple Llamas — but no Gemma line yet)

## Files

- `gemma3-4b/deploy.yaml` — SDL
- `gemma3-4b/README.md` — setup + customisation notes
- `README.md` — Gemma 3 4B added to **AI - GPU** TOC, alphabetical

No `config.json` included (optional per `CONTRIBUTING.md`; matches the pattern used by `ollama-gpu` and several other templates).

## Test plan

- [x] YAML parses cleanly
- [x] Resource profile matches real-world Gemma 3 4B requirements on consumer GPUs
- [x] Template name / folder name consistent across TOC, folder, and button URL
- [ ] Reviewer spot-check of SDL against current Akash provider offerings

Happy to tweak resources, pricing, or add a `config.json`/logo if preferred.