### PR TITLE
Add Dify template

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ To add a new template/resource:
 - [ChatChat](chatchat)
 - [Claude Code](claude-code)
 - [Daila](daila)
+- [Dify](dify)
 - [Eliza AI Agent](Elizaos-ai_Agents)
 - [Faster Whisper](faster-whisper-cpu)
 - [Flowise](flowise)

--- a/dify/README.md
+++ b/dify/README.md
@@ -1,0 +1,80 @@
+# Dify
+
+Dify is an open-source platform for building AI applications, workflows, agents, and RAG pipelines.
+
+[![Deploy on Akash](https://raw.githubusercontent.com/akash-network/console/refs/heads/main/apps/deploy-web/public/images/deploy-with-akash-btn.svg)](https://console.akash.network/new-deployment?step=edit-deployment&templateId=akash-network-awesome-akash-dify)
+
+## What this template deploys
+
+This Akash SDL deploys a minimal self-hosted Dify stack:
+
+- Dify API: `langgenius/dify-api:1.14.1`
+- Dify worker: `langgenius/dify-api:1.14.1`
+- Dify web UI: `langgenius/dify-web:1.14.1`
+- PostgreSQL 15
+- Redis 6
+- Weaviate vector database
+- Dify sandbox
+- Dify plugin daemon
+- Caddy reverse proxy
+
+The public endpoint is exposed through the `caddy` service on port `80`.
+
+## Before deployment
+
+Change all placeholder values in `deploy.yaml` before using this template in production:
+
+```bash
+CHANGE_ME_GENERATE_WITH_OPENSSL_RAND_BASE64_42
+CHANGE_ME_ADMIN_PASSWORD
+CHANGE_ME_DB_PASSWORD
+CHANGE_ME_REDIS_PASSWORD
+CHANGE_ME_WEAVIATE_API_KEY
+CHANGE_ME_SANDBOX_API_KEY
+CHANGE_ME_PLUGIN_DAEMON_KEY
+CHANGE_ME_PLUGIN_INNER_API_KEY
+```
+
+You can generate secrets with:
+
+```bash
+openssl rand -base64 42
+```
+
+Make sure that matching values are changed consistently across all services. For example, `DB_PASSWORD` in `api`, `worker`, `plugin-daemon`, and `POSTGRES_PASSWORD` in `db` must be identical.
+
+## Deployment
+
+Deploy `deploy.yaml` through Akash Console or Akash CLI.
+
+After the lease starts, open the URI of the `caddy` service.
+
+On first launch, Dify should run database migrations through the API service and allow initial setup using `INIT_PASSWORD`.
+
+## Notes and limitations
+
+This is an MVP template for `awesome-akash`, not a hardened production reference architecture.
+
+Important limitations:
+
+- The template uses local filesystem storage for Dify application files.
+- For production usage, S3-compatible storage such as MinIO is recommended.
+- The official Dify Docker Compose setup uses an SSRF proxy. This Akash MVP disables the SSRF proxy to avoid mounting external nginx/squid config files.
+- The template uses Caddy instead of the official nginx container so routing can be defined inline inside SDL.
+- If you add external OAuth providers, email links, or split domains, configure the public URL variables explicitly.
+
+## Resource profile
+
+Recommended minimum resources for this template:
+
+- CPU: 10+ total units across services
+- RAM: 18+ GiB total across services
+- Persistent storage: 80+ GiB total
+
+For small testing, you can reduce storage sizes, but Dify, Weaviate, and PostgreSQL should remain persistent.
+
+## Useful links
+
+- Dify documentation: https://docs.dify.ai/
+- Dify Docker Compose deployment: https://docs.dify.ai/en/self-host/quick-start/docker-compose
+- Dify GitHub repository: https://github.com/langgenius/dify

--- a/dify/README.md
+++ b/dify/README.md
@@ -1,8 +1,8 @@
 # Dify
 
-Dify is an open-source platform for building AI applications, workflows, agents, and RAG pipelines.
-
 [![Deploy on Akash](https://raw.githubusercontent.com/akash-network/console/refs/heads/main/apps/deploy-web/public/images/deploy-with-akash-btn.svg)](https://console.akash.network/new-deployment?step=edit-deployment&templateId=akash-network-awesome-akash-dify)
+
+Dify is an open-source platform for building AI applications, workflows, agents, and RAG pipelines.
 
 ## What this template deploys
 

--- a/dify/config.json
+++ b/dify/config.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../config.schema.json",
+  "ssh": false,
+  "logoUrl": "https://raw.githubusercontent.com/langgenius/dify/main/web/public/logo/logo-site.png"
+}

--- a/dify/deploy.yaml
+++ b/dify/deploy.yaml
@@ -1,0 +1,596 @@
+---
+version: "2.0"
+
+services:
+  caddy:
+    image: caddy:2-alpine
+    command:
+      - sh
+      - -c
+      - |
+        cat > /etc/caddy/Caddyfile <<'EOF'
+        :80 {
+          encode gzip zstd
+
+          reverse_proxy /console/api* api:5001
+          reverse_proxy /api* api:5001
+          reverse_proxy /v1* api:5001
+          reverse_proxy /files* api:5001
+          reverse_proxy /mcp* api:5001
+          reverse_proxy /triggers* api:5001
+          reverse_proxy /e/* plugin-daemon:5002
+          reverse_proxy /explore* web:3000
+          reverse_proxy /* web:3000
+        }
+        EOF
+
+        caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+
+  api:
+    image: langgenius/dify-api:1.14.1
+    env:
+      - MODE=api
+      - DEPLOY_ENV=PRODUCTION
+      - LOG_LEVEL=INFO
+      - LC_ALL=C.UTF-8
+      - LANG=C.UTF-8
+
+      - SECRET_KEY=CHANGE_ME_SECRET_KEY
+      - INIT_PASSWORD=CHANGE_ME_ADMIN_PASSWORD
+      - MIGRATION_ENABLED=true
+
+      - DB_TYPE=postgresql
+      - DB_USERNAME=postgres
+      - DB_PASSWORD=CHANGE_ME_DB_PASSWORD
+      - DB_HOST=db
+      - DB_PORT=5432
+      - DB_DATABASE=dify
+
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - REDIS_PASSWORD=CHANGE_ME_REDIS_PASSWORD
+      - CELERY_BROKER_URL=redis://:CHANGE_ME_REDIS_PASSWORD@redis:6379/1
+      - CELERY_BACKEND=redis
+
+      - WEB_API_CORS_ALLOW_ORIGINS=*
+      - CONSOLE_CORS_ALLOW_ORIGINS=*
+
+      - STORAGE_TYPE=opendal
+      - OPENDAL_SCHEME=s3
+
+      - OPENDAL_S3_ENDPOINT=http://minio:9000
+      - OPENDAL_S3_REGION=us-east-1
+      - OPENDAL_S3_BUCKET=difyai
+      - OPENDAL_S3_ACCESS_KEY_ID=CHANGE_ME_MINIO_ACCESS_KEY
+      - OPENDAL_S3_SECRET_ACCESS_KEY=CHANGE_ME_MINIO_SECRET_KEY
+      - OPENDAL_S3_ROOT=/
+      - OPENDAL_S3_ENABLE_VIRTUAL_HOST_STYLE=false
+
+      - S3_ENDPOINT=http://minio:9000
+      - S3_REGION=us-east-1
+      - S3_BUCKET_NAME=difyai
+      - S3_ACCESS_KEY=CHANGE_ME_MINIO_ACCESS_KEY
+      - S3_SECRET_KEY=CHANGE_ME_MINIO_SECRET_KEY
+      - S3_ADDRESS_STYLE=path
+      - S3_USE_AWS_MANAGED_IAM=false
+
+      - VECTOR_STORE=weaviate
+      - VECTOR_INDEX_NAME_PREFIX=Vector_index
+      - WEAVIATE_ENDPOINT=http://weaviate:8080
+      - WEAVIATE_API_KEY=CHANGE_ME_WEAVIATE_API_KEY
+      - WEAVIATE_GRPC_ENDPOINT=grpc://weaviate:50051
+      - WEAVIATE_TOKENIZATION=word
+
+      - CODE_EXECUTION_ENDPOINT=http://sandbox:8194
+      - CODE_EXECUTION_API_KEY=CHANGE_ME_SANDBOX_API_KEY
+      - SANDBOX_API_KEY=CHANGE_ME_SANDBOX_API_KEY
+      - SANDBOX_HTTP_PROXY=
+      - SANDBOX_HTTPS_PROXY=
+
+      - SSRF_PROXY_HTTP_URL=
+      - SSRF_PROXY_HTTPS_URL=
+
+      - PLUGIN_DAEMON_URL=http://plugin-daemon:5002
+      - PLUGIN_DAEMON_KEY=CHANGE_ME_PLUGIN_DAEMON_KEY
+      - PLUGIN_DIFY_INNER_API_KEY=CHANGE_ME_PLUGIN_INNER_API_KEY
+
+      - MARKETPLACE_ENABLED=true
+      - MARKETPLACE_API_URL=https://marketplace.dify.ai
+      - MARKETPLACE_URL=https://marketplace.dify.ai
+      - ENABLE_COLLABORATION_MODE=false
+      - NEXT_PUBLIC_SOCKET_URL=
+    expose:
+      - port: 5001
+        to:
+          - service: caddy
+          - service: plugin-daemon
+
+  worker:
+    image: langgenius/dify-api:1.14.1
+    env:
+      - MODE=worker
+      - DEPLOY_ENV=PRODUCTION
+      - LOG_LEVEL=INFO
+      - LC_ALL=C.UTF-8
+      - LANG=C.UTF-8
+
+      - SECRET_KEY=CHANGE_ME_SECRET_KEY
+      - MIGRATION_ENABLED=false
+
+      - DB_TYPE=postgresql
+      - DB_USERNAME=postgres
+      - DB_PASSWORD=CHANGE_ME_DB_PASSWORD
+      - DB_HOST=db
+      - DB_PORT=5432
+      - DB_DATABASE=dify
+
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - REDIS_PASSWORD=CHANGE_ME_REDIS_PASSWORD
+      - CELERY_BROKER_URL=redis://:CHANGE_ME_REDIS_PASSWORD@redis:6379/1
+      - CELERY_BACKEND=redis
+
+      - STORAGE_TYPE=opendal
+      - OPENDAL_SCHEME=s3
+
+      - OPENDAL_S3_ENDPOINT=http://minio:9000
+      - OPENDAL_S3_REGION=us-east-1
+      - OPENDAL_S3_BUCKET=difyai
+      - OPENDAL_S3_ACCESS_KEY_ID=CHANGE_ME_MINIO_ACCESS_KEY
+      - OPENDAL_S3_SECRET_ACCESS_KEY=CHANGE_ME_MINIO_SECRET_KEY
+      - OPENDAL_S3_ROOT=/
+      - OPENDAL_S3_ENABLE_VIRTUAL_HOST_STYLE=false
+
+      - S3_ENDPOINT=http://minio:9000
+      - S3_REGION=us-east-1
+      - S3_BUCKET_NAME=difyai
+      - S3_ACCESS_KEY=CHANGE_ME_MINIO_ACCESS_KEY
+      - S3_SECRET_KEY=CHANGE_ME_MINIO_SECRET_KEY
+      - S3_ADDRESS_STYLE=path
+      - S3_USE_AWS_MANAGED_IAM=false
+
+      - VECTOR_STORE=weaviate
+      - VECTOR_INDEX_NAME_PREFIX=Vector_index
+      - WEAVIATE_ENDPOINT=http://weaviate:8080
+      - WEAVIATE_API_KEY=CHANGE_ME_WEAVIATE_API_KEY
+      - WEAVIATE_GRPC_ENDPOINT=grpc://weaviate:50051
+      - WEAVIATE_TOKENIZATION=word
+
+      - CODE_EXECUTION_ENDPOINT=http://sandbox:8194
+      - CODE_EXECUTION_API_KEY=CHANGE_ME_SANDBOX_API_KEY
+      - SANDBOX_API_KEY=CHANGE_ME_SANDBOX_API_KEY
+      - SANDBOX_HTTP_PROXY=
+      - SANDBOX_HTTPS_PROXY=
+
+      - SSRF_PROXY_HTTP_URL=
+      - SSRF_PROXY_HTTPS_URL=
+
+      - PLUGIN_DAEMON_URL=http://plugin-daemon:5002
+      - PLUGIN_DAEMON_KEY=CHANGE_ME_PLUGIN_DAEMON_KEY
+      - PLUGIN_DIFY_INNER_API_KEY=CHANGE_ME_PLUGIN_INNER_API_KEY
+
+      - MARKETPLACE_ENABLED=true
+      - MARKETPLACE_API_URL=https://marketplace.dify.ai
+      - MARKETPLACE_URL=https://marketplace.dify.ai
+
+  web:
+    image: langgenius/dify-web:1.14.1
+    env:
+      - CONSOLE_API_URL=
+      - APP_API_URL=
+      - NEXT_PUBLIC_SOCKET_URL=
+      - NEXT_TELEMETRY_DISABLED=1
+      - TEXT_GENERATION_TIMEOUT_MS=60000
+      - MARKETPLACE_API_URL=https://marketplace.dify.ai
+      - MARKETPLACE_URL=https://marketplace.dify.ai
+    expose:
+      - port: 3000
+        to:
+          - service: caddy
+
+  db:
+    image: postgres:15-alpine
+    env:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=CHANGE_ME_DB_PASSWORD
+      - POSTGRES_DB=dify
+      - PGDATA=/var/lib/postgresql/data/pgdata
+    expose:
+      - port: 5432
+        to:
+          - service: api
+          - service: worker
+          - service: plugin-daemon
+    params:
+      storage:
+        db-data:
+          mount: /var/lib/postgresql/data
+          readOnly: false
+
+  redis:
+    image: redis:6-alpine
+    command:
+      - redis-server
+      - --requirepass
+      - CHANGE_ME_REDIS_PASSWORD
+    expose:
+      - port: 6379
+        to:
+          - service: api
+          - service: worker
+          - service: plugin-daemon
+    params:
+      storage:
+        redis-data:
+          mount: /data
+          readOnly: false
+
+  minio:
+    image: minio/minio:RELEASE.2024-12-18T13-15-44Z
+    command:
+      - sh
+      - -c
+      - |
+        minio server /data --console-address ":9001"
+    env:
+      - MINIO_ROOT_USER=CHANGE_ME_MINIO_ACCESS_KEY
+      - MINIO_ROOT_PASSWORD=CHANGE_ME_MINIO_SECRET_KEY
+    expose:
+      - port: 9000
+        to:
+          - service: api
+          - service: worker
+          - service: minio-setup
+      - port: 9001
+        to:
+          - service: minio-setup
+    params:
+      storage:
+        minio-data:
+          mount: /data
+          readOnly: false
+
+  minio-setup:
+    image: minio/mc:RELEASE.2024-11-21T17-21-54Z
+    command:
+      - sh
+      - -c
+      - |
+        until mc alias set local http://minio:9000 CHANGE_ME_MINIO_ACCESS_KEY CHANGE_ME_MINIO_SECRET_KEY; do
+          echo "waiting for minio..."
+          sleep 3
+        done
+
+        mc mb --ignore-existing local/difyai
+        mc anonymous set none local/difyai || true
+
+        echo "minio bucket difyai is ready"
+        tail -f /dev/null
+    expose:
+      - port: 8080
+        to:
+          - service: minio
+
+  weaviate:
+    image: semitechnologies/weaviate:1.27.0
+    env:
+      - PERSISTENCE_DATA_PATH=/var/lib/weaviate
+      - QUERY_DEFAULTS_LIMIT=25
+      - AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=false
+      - DEFAULT_VECTORIZER_MODULE=none
+      - CLUSTER_HOSTNAME=node1
+      - AUTHENTICATION_APIKEY_ENABLED=true
+      - AUTHENTICATION_APIKEY_ALLOWED_KEYS=CHANGE_ME_WEAVIATE_API_KEY
+      - AUTHENTICATION_APIKEY_USERS=hello@dify.ai
+      - AUTHORIZATION_ADMINLIST_ENABLED=true
+      - AUTHORIZATION_ADMINLIST_USERS=hello@dify.ai
+      - DISABLE_TELEMETRY=true
+    expose:
+      - port: 8080
+        to:
+          - service: api
+          - service: worker
+      - port: 50051
+        to:
+          - service: api
+          - service: worker
+    params:
+      storage:
+        weaviate-data:
+          mount: /var/lib/weaviate
+          readOnly: false
+
+  sandbox:
+    image: langgenius/dify-sandbox:0.2.15
+    env:
+      - API_KEY=CHANGE_ME_SANDBOX_API_KEY
+      - GIN_MODE=release
+      - WORKER_TIMEOUT=15
+      - ENABLE_NETWORK=true
+      - HTTP_PROXY=
+      - HTTPS_PROXY=
+      - SANDBOX_PORT=8194
+    expose:
+      - port: 8194
+        to:
+          - service: api
+          - service: worker
+    params:
+      storage:
+        sandbox-dependencies:
+          mount: /dependencies
+          readOnly: false
+
+  plugin-daemon:
+    image: langgenius/dify-plugin-daemon:0.6.1-local
+    env:
+      - DB_TYPE=postgresql
+      - DB_USERNAME=postgres
+      - DB_PASSWORD=CHANGE_ME_DB_PASSWORD
+      - DB_HOST=db
+      - DB_PORT=5432
+      - DB_DATABASE=dify
+      - DB_PLUGIN_DATABASE=dify
+
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - REDIS_PASSWORD=CHANGE_ME_REDIS_PASSWORD
+
+      - SERVER_PORT=5002
+      - SERVER_KEY=CHANGE_ME_PLUGIN_DAEMON_KEY
+
+      - DIFY_INNER_API_URL=http://api:5001
+      - DIFY_INNER_API_KEY=CHANGE_ME_PLUGIN_INNER_API_KEY
+
+      - PLUGIN_REMOTE_INSTALLING_HOST=0.0.0.0
+      - PLUGIN_REMOTE_INSTALLING_PORT=5003
+      - FORCE_VERIFYING_SIGNATURE=true
+
+      - PLUGIN_STORAGE_TYPE=local
+      - PLUGIN_STORAGE_LOCAL_ROOT=/app/storage
+      - PLUGIN_WORKING_PATH=/app/storage/cwd
+      - PLUGIN_INSTALLED_PATH=plugin
+      - PLUGIN_PACKAGE_CACHE_PATH=plugin_packages
+      - PLUGIN_MEDIA_CACHE_PATH=assets
+
+      - S3_USE_AWS_MANAGED_IAM=false
+      - PIP_MIRROR_URL=
+    expose:
+      - port: 5002
+        to:
+          - service: api
+          - service: caddy
+    params:
+      storage:
+        plugin-storage:
+          mount: /app/storage
+          readOnly: false
+
+profiles:
+  compute:
+    caddy:
+      resources:
+        cpu:
+          units: 0.25
+        memory:
+          size: 256Mi
+        storage:
+          size: 512Mi
+
+    api:
+      resources:
+        cpu:
+          units: 2
+        memory:
+          size: 4Gi
+        storage:
+          size: 1Gi
+
+    worker:
+      resources:
+        cpu:
+          units: 2
+        memory:
+          size: 4Gi
+        storage:
+          size: 1Gi
+
+    web:
+      resources:
+        cpu:
+          units: 1
+        memory:
+          size: 1Gi
+        storage:
+          size: 1Gi
+
+    db:
+      resources:
+        cpu:
+          units: 1
+        memory:
+          size: 2Gi
+        storage:
+          - size: 1Gi
+          - name: db-data
+            size: 20Gi
+            attributes:
+              persistent: true
+              class: beta3
+
+    redis:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          - size: 512Mi
+          - name: redis-data
+            size: 4Gi
+            attributes:
+              persistent: true
+              class: beta3
+
+    minio:
+      resources:
+        cpu:
+          units: 1
+        memory:
+          size: 1Gi
+        storage:
+          - size: 1Gi
+          - name: minio-data
+            size: 20Gi
+            attributes:
+              persistent: true
+              class: beta3
+
+    minio-setup:
+      resources:
+        cpu:
+          units: 0.25
+        memory:
+          size: 256Mi
+        storage:
+          size: 512Mi
+
+    weaviate:
+      resources:
+        cpu:
+          units: 2
+        memory:
+          size: 4Gi
+        storage:
+          - size: 1Gi
+          - name: weaviate-data
+            size: 20Gi
+            attributes:
+              persistent: true
+              class: beta3
+
+    sandbox:
+      resources:
+        cpu:
+          units: 1
+        memory:
+          size: 1Gi
+        storage:
+          - size: 1Gi
+          - name: sandbox-dependencies
+            size: 8Gi
+            attributes:
+              persistent: true
+              class: beta3
+
+    plugin-daemon:
+      resources:
+        cpu:
+          units: 1
+        memory:
+          size: 2Gi
+        storage:
+          - size: 1Gi
+          - name: plugin-storage
+            size: 10Gi
+            attributes:
+              persistent: true
+              class: beta3
+
+  placement:
+    akash:
+      pricing:
+        caddy:
+          denom: uact
+          amount: 1000
+        api:
+          denom: uact
+          amount: 10000
+        worker:
+          denom: uact
+          amount: 10000
+        web:
+          denom: uact
+          amount: 5000
+        db:
+          denom: uact
+          amount: 5000
+        redis:
+          denom: uact
+          amount: 2000
+        minio:
+          denom: uact
+          amount: 5000
+        minio-setup:
+          denom: uact
+          amount: 1000
+        weaviate:
+          denom: uact
+          amount: 10000
+        sandbox:
+          denom: uact
+          amount: 5000
+        plugin-daemon:
+          denom: uact
+          amount: 5000
+
+deployment:
+  caddy:
+    akash:
+      profile: caddy
+      count: 1
+
+  api:
+    akash:
+      profile: api
+      count: 1
+
+  worker:
+    akash:
+      profile: worker
+      count: 1
+
+  web:
+    akash:
+      profile: web
+      count: 1
+
+  db:
+    akash:
+      profile: db
+      count: 1
+
+  redis:
+    akash:
+      profile: redis
+      count: 1
+
+  minio:
+    akash:
+      profile: minio
+      count: 1
+
+  minio-setup:
+    akash:
+      profile: minio-setup
+      count: 1
+
+  weaviate:
+    akash:
+      profile: weaviate
+      count: 1
+
+  sandbox:
+    akash:
+      profile: sandbox
+      count: 1
+
+  plugin-daemon:
+    akash:
+      profile: plugin-daemon
+      count: 1


### PR DESCRIPTION
Added a Dify template for Akash.

The template deploys a self-hosted Dify stack with PostgreSQL, Redis, Weaviate, MinIO, Sandbox, Plugin Daemon, and Caddy as a reverse proxy.

MinIO is used as S3-compatible storage for Dify files instead of local filesystem storage, which works better for Akash persistent volume deployments.

The SDL was tested on Akash and starts successfully.