### PR TITLE
Add LiteLLM template

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ To add a new template/resource:
 - [Hermes Agent](Hermes-Agent)
 - [InvokeAI](invoke-ai-cpu)
 - [Langflow](langflow)
+- [LiteLLM Proxy](litellm)
 - [Morpheus Lumerin Node](morpheus-lumerin-node)
 - [Ollama](ollama-cpu)
 - [OpenClaw](openclaw)

--- a/litellm/README.md
+++ b/litellm/README.md
@@ -4,18 +4,6 @@ LiteLLM Proxy is a self-hosted OpenAI-compatible AI gateway.
 
 [![Deploy on Akash](https://raw.githubusercontent.com/akash-network/console/refs/heads/main/apps/deploy-web/public/images/deploy-with-akash-btn.svg)](https://console.akash.network/new-deployment?step=edit-deployment&templateId=akash-network-awesome-akash-litellm)
 
-## What this template deploys
-
-This Akash SDL deploys:
-
-- LiteLLM Proxy
-- PostgreSQL for proxy state, keys, users, models, and spend tracking
-- A small inline `config.yaml` with one example OpenAI model
-
-Public port:
-
-- `4000` — LiteLLM Proxy API and UI
-
 ## Before deployment
 
 Change these placeholder values in `deploy.yaml` before deploying:

--- a/litellm/README.md
+++ b/litellm/README.md
@@ -1,0 +1,164 @@
+# LiteLLM Proxy
+
+LiteLLM Proxy is a self-hosted OpenAI-compatible AI gateway.
+
+[![Deploy on Akash](https://raw.githubusercontent.com/akash-network/console/refs/heads/main/apps/deploy-web/public/images/deploy-with-akash-btn.svg)](https://console.akash.network/new-deployment?step=edit-deployment&templateId=akash-network-awesome-akash-litellm)
+
+## What this template deploys
+
+This Akash SDL deploys:
+
+- LiteLLM Proxy
+- PostgreSQL for proxy state, keys, users, models, and spend tracking
+- A small inline `config.yaml` with one example OpenAI model
+
+Public port:
+
+- `4000` — LiteLLM Proxy API and UI
+
+## Before deployment
+
+Change these placeholder values in `deploy.yaml` before deploying:
+
+```bash
+CHANGE_ME_LITELLM_MASTER_KEY
+CHANGE_ME_LITELLM_SALT_KEY
+CHANGE_ME_POSTGRES_PASSWORD
+CHANGE_ME_OPENAI_API_KEY
+CHANGE_ME_UI_PASSWORD
+```
+
+Generate strong values for the master key, salt key, database password, and UI password.
+
+Examples:
+
+```bash
+openssl rand -base64 32
+```
+
+The `LITELLM_SALT_KEY` is used to encrypt and decrypt stored LLM API keys. Do not change it after adding models in LiteLLM.
+
+## Default model
+
+The template includes one example model:
+
+```yaml
+model_name: gpt-4o-mini
+model: openai/gpt-4o-mini
+api_key: os.environ/OPENAI_API_KEY
+```
+
+You can change this section in the inline `config.yaml` inside `deploy.yaml`.
+
+Example for an OpenAI-compatible endpoint, such as vLLM or Ollama behind an OpenAI-compatible API:
+
+```yaml
+model_list:
+  - model_name: local-model
+    litellm_params:
+      model: openai/local-model
+      api_base: http://your-openai-compatible-endpoint:8000/v1
+      api_key: none
+```
+
+## Using the proxy
+
+Use the Akash endpoint assigned to port `4000` as your OpenAI-compatible base URL.
+
+Example:
+
+```bash
+curl http://<akash-host>:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer CHANGE_ME_LITELLM_MASTER_KEY" \
+  -d '{
+    "model": "gpt-4o-mini",
+    "messages": [
+      {"role": "user", "content": "Hello from Akash"}
+    ]
+  }'
+```
+
+For OpenAI SDK-compatible clients:
+
+```bash
+OPENAI_BASE_URL=http://<akash-host>:4000/v1
+OPENAI_API_KEY=CHANGE_ME_LITELLM_MASTER_KEY
+```
+
+## PostgreSQL
+
+The database data is stored in a persistent volume mounted at:
+
+```bash
+/var/lib/postgresql/data
+```
+
+Default persistent storage size:
+
+```bash
+10Gi
+```
+
+You can increase it in the `profiles.compute.db.resources.storage` section.
+
+## Logs
+
+Check LiteLLM logs:
+
+```bash
+akash provider lease-logs \
+  --dseq <DSEQ> \
+  --gseq 1 \
+  --oseq 1 \
+  --provider <PROVIDER_ADDRESS> \
+  --service litellm
+```
+
+Check PostgreSQL logs:
+
+```bash
+akash provider lease-logs \
+  --dseq <DSEQ> \
+  --gseq 1 \
+  --oseq 1 \
+  --provider <PROVIDER_ADDRESS> \
+  --service db
+```
+
+## Troubleshooting
+
+### LiteLLM starts but model calls fail
+
+Check that the model config and provider API key are correct:
+
+```bash
+OPENAI_API_KEY=CHANGE_ME_OPENAI_API_KEY
+```
+
+Also check that the request uses the model name from `config.yaml`:
+
+```bash
+gpt-4o-mini
+```
+
+### Unauthorized requests
+
+Requests must include the master key:
+
+```bash
+Authorization: Bearer CHANGE_ME_LITELLM_MASTER_KEY
+```
+
+### Database connection errors
+
+Make sure this value uses the same PostgreSQL password as the `db` service:
+
+```bash
+DATABASE_URL=postgresql://litellm:CHANGE_ME_POSTGRES_PASSWORD@db:5432/litellm
+```
+
+## Notes
+
+This template is intended as a simple LiteLLM Proxy deployment for Akash.
+For production use, consider adding your own domain, TLS termination, stricter access controls, Redis for caching/rate limits, and a more complete model configuration.

--- a/litellm/README.md
+++ b/litellm/README.md
@@ -51,7 +51,7 @@ model_list:
 
 ## Using the proxy
 
-Use the Akash endpoint assigned to port `4000` as your OpenAI-compatible base URL.
+Use the Akash URIs assigned to port `4000` as your OpenAI-compatible base URL.
 
 Example:
 

--- a/litellm/config.json
+++ b/litellm/config.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../config.schema.json",
+  "ssh": false,
+  "logoUrl": "https://raw.githubusercontent.com/BerriAI/litellm/refs/heads/litellm_internal_staging/ui/litellm-dashboard/public/assets/logos/litellm_logo.jpg"
+}

--- a/litellm/deploy.yaml
+++ b/litellm/deploy.yaml
@@ -1,0 +1,105 @@
+---
+version: "2.0"
+
+services:
+  litellm:
+    image: ghcr.io/berriai/litellm-database:latest@sha256:069da8855c7bf0a39861fcd9884f134670128b79aa930a4af0c9219a0433b83f
+    command:
+      - sh
+      - -c
+      - |
+        cat > /app/config.yaml <<'CONFIG_EOF'
+        model_list:
+          - model_name: gpt-4o-mini
+            litellm_params:
+              model: openai/gpt-4o-mini
+              api_key: os.environ/OPENAI_API_KEY
+
+        general_settings:
+          master_key: os.environ/LITELLM_MASTER_KEY
+          database_url: os.environ/DATABASE_URL
+          store_model_in_db: true
+
+        litellm_settings:
+          drop_params: true
+        CONFIG_EOF
+
+        litellm --config /app/config.yaml --host 0.0.0.0 --port 4000
+    env:
+      - LITELLM_MASTER_KEY=CHANGE_ME_LITELLM_MASTER_KEY
+      - LITELLM_SALT_KEY=CHANGE_ME_LITELLM_SALT_KEY
+      - DATABASE_URL=postgresql://litellm:CHANGE_ME_POSTGRES_PASSWORD@db:5432/litellm
+      - STORE_MODEL_IN_DB=True
+      - OPENAI_API_KEY=CHANGE_ME_OPENAI_API_KEY
+      - LITELLM_LOG=INFO
+      - UI_USERNAME=admin
+      - UI_PASSWORD=CHANGE_ME_UI_PASSWORD
+    expose:
+      - port: 4000
+        as: 4000
+        to:
+          - global: true
+          - service: db
+
+  db:
+    image: postgres:15-alpine
+    env:
+      - POSTGRES_USER=litellm
+      - POSTGRES_PASSWORD=CHANGE_ME_POSTGRES_PASSWORD
+      - POSTGRES_DB=litellm
+      - PGDATA=/var/lib/postgresql/data/pgdata
+    expose:
+      - port: 5432
+        to:
+          - service: litellm
+    params:
+      storage:
+        db-data:
+          mount: /var/lib/postgresql/data
+          readOnly: false
+
+profiles:
+  compute:
+    litellm:
+      resources:
+        cpu:
+          units: 1
+        memory:
+          size: 2Gi
+        storage:
+          size: 2Gi
+
+    db:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 1Gi
+        storage:
+          - size: 1Gi
+          - name: db-data
+            size: 10Gi
+            attributes:
+              persistent: true
+              class: beta3
+
+  placement:
+    akash:
+      pricing:
+        litellm:
+          denom: uact
+          amount: 5000
+        db:
+          denom: uact
+          amount: 3000
+
+deployment:
+  litellm:
+    akash:
+      profile: litellm
+      count: 1
+
+  db:
+    akash:
+      profile: db
+      count: 1


### PR DESCRIPTION
Added a LiteLLM Proxy template for Akash.

The template deploys LiteLLM with PostgreSQL and persistent storage, exposing an OpenAI-compatible API endpoint on port `4000`.

This makes it easier to use Akash-hosted or external LLMs through a single gateway, and can be paired with tools like Dify, Open WebUI, Langflow, Flowise, vLLM, and Ollama.

Users need to replace all `CHANGE_ME_*` values before deployment.