### PR TITLE
Add ZGC under Blockchain (lightweight PoS chain, Akash-deployable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Awesome DeFi apps you can deploy on Akash
 - [Witness Chain Watchtower](witnesschain-watchtower)
 - [Zcash - Zcashd](zcash-zcashd)
 - [Zcash - Zebra](zcash-zebra)
+- [ZGC - Lightweight PoS chain (Python)](https://github.com/0riginal-claw/zgc) - Single-file Python proof-of-stake chain for anchoring AI agent state. Deployable on Akash with minimal resources.
 
 ### Business
 


### PR DESCRIPTION
### Adding ZGC under Blockchain

ZGC (Zach Gladstone Chain Coin) is a lightweight Python proof-of-stake chain that's **deployable on Akash as a stateless validator container**.

**Why it fits the Akash Blockchain section:**

- Deployable on Akash (small footprint: HTTP gossip + JSONL append-only chain; no GPU, no SSD, no large state).
- Validator-runnable on minimal compute resources — perfect fit for Akash leases.
- MIT licensed, open source, active development.
- One-line install: `curl -sL https://zgc.run | bash`

**Repository:** https://github.com/0riginal-claw/zgc
**TOKEN.md spec:** https://github.com/0riginal-claw/zgc/blob/main/state/zgc/TOKEN.md
**Chain node:** https://github.com/0riginal-claw/zgc/blob/main/scripts/zg_chain_node.py

I'm planning to ship an Akash SDL (`deploy.yaml`) for one-click ZGC validator deployment as a follow-up; happy to add that to the same entry once shipped.

Open to category placement adjustments per maintainer preference.
