### PR TITLE
Phoenix template

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ To add a new template/resource:
 - [Open WebUI](open-webui-cpu)
 - [Piper TTS](Piper-TTS)
 - [PrivateGPT](privategpt-cpu)
+- [Phoenix](phoenix)
 - [Serge](serge-cpu)
 - [Stable Diffusion](stable-diffusion-ui)
 - [Terminal GPT](tgpt)

--- a/phoenix/README.md
+++ b/phoenix/README.md
@@ -1,0 +1,106 @@
+# Phoenix
+
+[![Deploy on Akash](https://raw.githubusercontent.com/akash-network/console/refs/heads/main/apps/deploy-web/public/images/deploy-with-akash-btn.svg)](https://console.akash.network/new-deployment?step=edit-deployment&templateId=akash-network-awesome-akash-phoenix)
+
+Phoenix is an open-source AI observability and evaluation platform for LLM applications.
+
+## What this template deploys
+
+This Akash SDL deploys:
+
+- Phoenix server
+- PostgreSQL for traces, evals, datasets, and experiments
+- Persistent storage for Phoenix working data
+- Persistent storage for PostgreSQL
+
+Public ports:
+
+- `6006` — Phoenix UI and OTLP HTTP collector
+- `4317` — OTLP gRPC collector
+
+Phoenix accepts OTLP HTTP traces on:
+
+```bash
+http://<akash-host>:<forwarded_port_6006>/v1/traces
+```
+
+## Before deployment
+
+Change these placeholder values in `deploy.yaml` before deploying:
+
+```bash
+CHANGE_POSTGRES_PASSWORD
+CHANGE_ADMIN_PASSWORD
+```
+
+Generate strong values, for example:
+
+```bash
+openssl rand -base64 32
+```
+
+The initial admin password is controlled by:
+
+```bash
+PHOENIX_DEFAULT_ADMIN_INITIAL_PASSWORD=CHANGE_ADMIN_PASSWORD
+```
+
+The default admin email is:
+
+```bash
+admin@localhost
+```
+
+Changing `PHOENIX_DEFAULT_ADMIN_INITIAL_PASSWORD` after the admin user has already been created will not reset the password. Update it from the Phoenix UI or redeploy with a fresh database.
+
+## Storage
+
+Phoenix uses PostgreSQL through:
+
+```bash
+PHOENIX_SQL_DATABASE_URL=postgresql://phoenix:CHANGE_POSTGRES_PASSWORD@db:5432/phoenix
+```
+
+PostgreSQL data is stored in a persistent volume mounted at:
+
+```bash
+/var/lib/postgresql/data
+```
+
+Phoenix working data is stored in a persistent volume mounted at:
+
+```bash
+/mnt/data
+```
+
+Default persistent storage sizes:
+
+```bash
+Phoenix working data: 20Gi
+PostgreSQL data: 20Gi
+```
+
+You can increase them in the `profiles.compute` section.
+
+## Sending traces
+
+Use the Akash endpoint assigned to port `<forwarded_port_6006>` as the Phoenix collector endpoint.
+
+Example OTLP HTTP endpoint:
+
+```bash
+http://<akash-host>:<forwarded_port_6006>/v1/traces
+```
+
+For OpenInference or OpenTelemetry-based clients, configure the collector endpoint to this URL.
+
+The gRPC collector is exposed on port `<forwarded_port_4317>`:
+
+```bash
+<akash-host>:<forwarded_port_4317>
+```
+
+## Notes
+
+This template is intended as a simple self-hosted Phoenix deployment for Akash.
+For production use, consider adding your own domain, TLS termination, authentication hardening, backup policy, and retention settings.

--- a/phoenix/config.json
+++ b/phoenix/config.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../config.schema.json",
+  "ssh": false,
+  "logoUrl": "https://raw.githubusercontent.com/Arize-ai/phoenix/refs/heads/main/docs/favicon.png"
+}

--- a/phoenix/deploy.yaml
+++ b/phoenix/deploy.yaml
@@ -1,0 +1,95 @@
+---
+version: "2.0"
+services:
+  phoenix:
+    image: arizephoenix/phoenix:latest@sha256:f94982a4dfa6b7852d2457d73a40015c5e8ab11a7863d77e159604019a67e8c5
+    env:
+      - PHOENIX_HOST=0.0.0.0
+      - PHOENIX_PORT=6006
+      - PHOENIX_GRPC_PORT=4317
+      - PHOENIX_SQL_DATABASE_URL=postgresql://phoenix:CHANGE_POSTGRES_PASSWORD@db:5432/phoenix
+      - PHOENIX_WORKING_DIR=/mnt/data
+      - PHOENIX_DEFAULT_ADMIN_INITIAL_PASSWORD=CHANGE_ADMIN_PASSWORD
+      - PHOENIX_ENABLE_STRONG_PASSWORD_POLICY=true
+      - PHOENIX_TELEMETRY_ENABLED=false
+      - PHOENIX_ALLOW_EXTERNAL_RESOURCES=true
+      - PHOENIX_ENABLE_PROMETHEUS=false
+      - PHOENIX_LOGGING_LEVEL=INFO
+    expose:
+      - port: 6006
+        as: 6006
+        to:
+          - global: true
+          - service: db
+      - port: 4317
+        as: 4317
+        to:
+          - global: true
+    params:
+      storage:
+        phoenix-data:
+          mount: /mnt/data
+          readOnly: false
+  db:
+    image: postgres:15-alpine
+    env:
+      - POSTGRES_USER=phoenix
+      - POSTGRES_PASSWORD=CHANGE_POSTGRES_PASSWORD
+      - POSTGRES_DB=phoenix
+      - PGDATA=/var/lib/postgresql/data/pgdata
+    expose:
+      - port: 5432
+        to:
+          - service: phoenix
+    params:
+      storage:
+        db-data:
+          mount: /var/lib/postgresql/data
+          readOnly: false
+profiles:
+  compute:
+    phoenix:
+      resources:
+        cpu:
+          units: 2
+        memory:
+          size: 4Gi
+        storage:
+          - size: 2Gi
+          - name: phoenix-data
+            size: 20Gi
+            attributes:
+              persistent: true
+              class: beta3
+    db:
+      resources:
+        cpu:
+          units: 1
+        memory:
+          size: 2Gi
+        storage:
+          - size: 1Gi
+          - name: db-data
+            size: 20Gi
+            attributes:
+              persistent: true
+              class: beta3
+  placement:
+    akash:
+      pricing:
+        phoenix:
+          denom: uact
+          amount: 10000
+        db:
+          denom: uact
+          amount: 5000
+
+deployment:
+  phoenix:
+    akash:
+      profile: phoenix
+      count: 1
+  db:
+    akash:
+      profile: db
+      count: 1


### PR DESCRIPTION
Phoenix template for Akash.

The template deploys Phoenix with PostgreSQL and persistent storage, exposing the UI and OTLP HTTP endpoint on port `6006`, plus OTLP gRPC on port `4317`.

Phoenix helps with AI observability, tracing, debugging, and evaluating LLM/RAG applications.