### PR TITLE
Update Razer-AIKit to aikit0.4.0

### DIFF
--- a/Razer-AIKit/deploy.yml
+++ b/Razer-AIKit/deploy.yml
@@ -2,7 +2,7 @@
 version: "2.0"
 services:
   razer-aikit-image-gen:
-    image: razerofficial/aikit:cuda13.0-torch2.10.0-vllm0.18.0-aikit0.3.2
+    image: razerofficial/aikit:cuda13.0-torch2.11.0-vllm0.20.0-aikit0.4.0
     expose:
       - port: 8000
         as: 8000
@@ -18,20 +18,14 @@ services:
           - global: true
     command:
       - bash
-      - "-c"
+      - "-lc"
     args:
       - |
-        source /etc/profile.d/set_cuda_toolkit_path.sh
-        source /etc/profile.d/add_scripts_to_path.sh
-        source /etc/profile.d/add_benchmarks_to_path.sh
-        source /etc/profile.d/fix_huggingface_owner.sh
-        source /etc/profile.d/remove_ray_leftover.sh
         set -m
-
+        export SHELL=`readlink -f /proc/$$$$/exe`
         rzr-aikit ui run &
         AIKIT_PID=$!
         trap 'wait $AIKIT_PID' SIGCHLD SIGTERM SIGINT
-
         jupyter lab \
           --ip="0.0.0.0" \
           --port=8888 \
@@ -43,70 +37,16 @@ profiles:
     razer-aikit-image-gen:
       resources:
         cpu:
-          units: 4
+          units: 1
         memory:
-          size: 16Gb
+          size: 4Gi
         storage:
-          - size: 200Gi
+          - size: 10Gi
         gpu:
           units: 1
           attributes:
             vendor:
               nvidia:
-                - model: rtx3090
-                  ram: 24Gi
-                  interface: pcie
-                - model: rtx3090ti
-                  ram: 24Gi
-                  interface: pcie
-                - model: rtx4090
-                  ram: 24Gi
-                  interface: pcie
-                - model: rtx5090
-                  ram: 32Gi
-                  interface: pcie
-                - model: rtxa6000
-                  ram: 48Gi
-                  interface: pcie
-                - model: rtx6000
-                  ram: 24Gi
-                  interface: pcie
-                - model: rtx8000
-                  ram: 48Gi
-                  interface: pcie
-                - model: h100
-                  ram: 80Gi
-                  interface: pcie
-                - model: h200
-                  ram: 141Gi
-                  interface: sxm
-                - model: h200nvl
-                  ram: 141Gi
-                  interface: pcie
-                - model: a100
-                  ram: 80Gi
-                  interface: pcie
-                - model: a40
-                  ram: 48Gi
-                  interface: pcie
-                - model: p40
-                  ram: 24Gi
-                  interface: pcie
-                - model: pro6000we
-                  ram: 96Gi
-                  interface: pcie
-                - model: pro6000mq
-                  ram: 96Gi
-                  interface: pcie
-                - model: pro6000se
-                  ram: 96Gi
-                  interface: pcie
-                - model: a100
-                  ram: 40Gi
-                  interface: pcie
-                - model: a100
-                  ram: 64Gi
-                  interface: pcie
   placement:
     dcloud:
       pricing:


### PR DESCRIPTION
Updates the Razer-AIKit template to the `aikit0.4.0` image and adjusts the SDL accordingly.

## Changes
- Bump image to `razerofficial/aikit:cuda13.0-torch2.11.0-vllm0.20.0-aikit0.4.0`
- Switch container shell invocation to a login shell (`bash -lc`) and simplify startup (profile sourcing now handled by the login shell; set `SHELL` for Jupyter)
- Reduce default profile resources (cpu 4→1, memory 16Gb→4Gi, storage 200Gi→10Gi)
- Remove the explicit GPU model allowlist