### PR TITLE
Add Logos Blockchain Node template

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Awesome DeFi apps you can deploy on Akash
 - [Handshake](handshake)
 - [Injective](injective)
 - [Kadena](Kadena)
+- [Logos Blockchain Node](logos-blockchain-node)
 - [Metal Validator](metal-validator)
 - [Near Node](near)
 - [POKT Network](pokt-network)

--- a/logos-blockchain-node/README.md
+++ b/logos-blockchain-node/README.md
@@ -1,0 +1,73 @@
+# Logos Blockchain Node
+
+Deploy a [Logos Blockchain](https://github.com/logos-blockchain/logos-blockchain) node on Akash Network.
+
+Logos Blockchain is a privacy-preserving, censorship-resistant blockchain for decentralized network states. It combines zero-knowledge proofs, a mix network (Blend) for anonymity, and a modular service architecture.
+
+## Quick Start
+
+Deploy using the SDL in this directory. On first boot the node automatically:
+1. Runs `logos-blockchain-node init` against the testnet bootstrap peers to generate `user_config.yaml`
+2. Starts the node with that config
+
+The generated config and all chain state are written to `/state`, which is mounted as a persistent volume so they survive pod restarts.
+
+## Ports
+
+| Port | Protocol | Exposed | Description |
+|------|----------|---------|-------------|
+| 8080 | TCP | No (localhost only) | HTTP API |
+| 3000 | UDP | Yes | libp2p P2P networking |
+| 3400 | UDP | Yes | Blend mix-network |
+
+The HTTP API (8080) is intentionally not exposed publicly. To query it, exec into the running container:
+
+```bash
+curl http://localhost:8080/cryptarchia/info
+```
+
+Your node will be in `Bootstrapping` mode for a few minutes with `slot` and `height` steadily increasing. After that it moves to `Online` mode.
+
+Compare against the fleet at the [Logos Testnet dashboard](https://testnet.blockchain.logos.co/web/).
+
+## First-time Setup (setting the correct external IP)
+
+The node needs to advertise its publicly reachable IP to the network. On Akash, the leased IP is not visible from inside the container (egress goes through the cluster IP, not the leased IP), so it must be set manually:
+
+1. Deploy with `EXTERNAL_IP` left empty — the node starts with NAT traversal
+2. Find the leased IP in the Akash Console
+3. Back up the config: `base64 -w 0 /state/user_config.yaml`
+4. Update the SDL: set `EXTERNAL_IP=<leased-ip>` and `USER_CONFIG_BASE64=<backup>`
+5. Redeploy — `init` reruns with `--external-address /ip4/<leased-ip>/udp/3000/quic-v1`, keys restored from backup
+
+From this point the IP is stable and restores work without any manual steps.
+
+## Backup and Restore
+
+`user_config.yaml` holds your node identity and wallet keys. It lives on the persistent volume but is lost if the lease is closed.
+
+**Backup** — exec into the container and run:
+```bash
+base64 -w 0 /state/user_config.yaml
+```
+
+**Restore** — paste the base64 output into the `USER_CONFIG_BASE64` env var in the SDL before deploying. The startup script will write the config to disk instead of running `init`, preserving your node identity and keys.
+
+## Getting Funds
+
+Find your wallet key in the generated config:
+
+```bash
+grep -A3 known_keys /state/user_config.yaml
+```
+
+Then request tokens from the [testnet faucet](https://testnet.blockchain.logos.co/web/faucet/) (credentials from the Logos team via [Discord](https://discord.gg/logos-network)).
+
+## Resources
+
+The SDL provisions:
+- 2 vCPU
+- 4 Gi RAM
+- 20 Gi persistent storage for chain state + config
+
+Adjust these in `profiles.compute` to match your needs.

--- a/logos-blockchain-node/config.json
+++ b/logos-blockchain-node/config.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../config.schema.json",
+  "ssh": false,
+  "logoUrl": "https://avatars.githubusercontent.com/u/247224156?v=4"
+}

--- a/logos-blockchain-node/deploy.yaml
+++ b/logos-blockchain-node/deploy.yaml
@@ -1,0 +1,101 @@
+---
+version: "2.0"
+
+services:
+  logos-blockchain-node:
+    image: ghcr.io/vpavlin/logos-blockchain-node:0.1.2-curl-3
+    env:
+      - "USER_CONFIG_BASE64=" # Optional: base64-encoded user_config.yaml. If set, skips init and uses this config instead.
+      - "EXTERNAL_IP="        # Optional: manual override for the leased IP. Auto-detected from Kubernetes API if not set.
+    command:
+      - "sh"
+      - "-c"
+    args:
+      - |
+        cd /state
+
+        # Restore or generate config
+        if [ -n "$USER_CONFIG_BASE64" ]; then
+          echo "$USER_CONFIG_BASE64" | base64 -d > user_config.yaml
+        elif [ ! -f user_config.yaml ]; then
+          logos-blockchain-node init \
+            -p /ip4/65.109.51.37/udp/3000/quic-v1 \
+            -p /ip4/65.109.51.37/udp/3001/quic-v1 \
+            -p /ip4/65.109.51.37/udp/3002/quic-v1 \
+            -p /ip4/65.109.51.37/udp/3003/quic-v1
+        fi
+
+        # Detect leased IP on every startup
+        DETECTED_IP=""
+        if [ -f /var/run/secrets/kubernetes.io/serviceaccount/token ]; then
+          KUBE_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+          KUBE_NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace 2>/dev/null || echo "default")
+          DETECTED_IP=$(curl -s --max-time 5 \
+            -H "Authorization: Bearer $KUBE_TOKEN" \
+            --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+            "https://kubernetes.default.svc/api/v1/namespaces/$KUBE_NAMESPACE/services" 2>/dev/null | \
+            jq -r '.items[] | select(.spec.type=="LoadBalancer") | .status.loadBalancer.ingress[0].ip // empty' 2>/dev/null | head -1)
+        fi
+        PUBLIC_IP="${EXTERNAL_IP:-$DETECTED_IP}"
+        if [ -n "$PUBLIC_IP" ]; then
+          echo "Setting static external address: $PUBLIC_IP"
+          yq -i ".network.backend.swarm.nat = {\"type\": \"static\", \"external_address\": \"/ip4/$PUBLIC_IP/udp/3000/quic-v1\"}" user_config.yaml
+        else
+          echo "Warning: could not detect leased IP, node will rely on NAT traversal"
+        fi
+
+        logos-blockchain-node user_config.yaml || sleep infinity
+    expose:
+      - port: 3000
+        proto: udp
+        as: 3000
+        to:
+          - global: true
+            ip: logos-node-ip
+      - port: 3400
+        proto: udp
+        as: 3400
+        to:
+          - global: true
+            ip: logos-node-ip
+    params:
+      storage:
+        state:
+          mount: /state
+
+profiles:
+  compute:
+    logos-blockchain-node:
+      resources:
+        cpu:
+          units: 2.0
+        memory:
+          size: 4Gi
+        storage:
+          - size: 512Mi
+          - name: state
+            size: 20Gi
+            attributes:
+              persistent: true
+              class: beta3
+  placement:
+    akash:
+      attributes:
+        host: akash
+      signedBy:
+        anyOf:
+          - "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63"
+      pricing:
+        logos-blockchain-node:
+          denom: uact
+          amount: 10000
+
+endpoints:
+  logos-node-ip:
+    kind: ip
+
+deployment:
+  logos-blockchain-node:
+    akash:
+      profile: logos-blockchain-node
+      count: 1


### PR DESCRIPTION
## Summary

- Adds deployment template for [Logos Blockchain Node](https://github.com/logos-blockchain/logos-blockchain) — a privacy-preserving, censorship-resistant blockchain using ZK proofs and the Blend mix-network
- Uses Akash IP lease for a stable public address across lease restarts
- Auto-detects the leased IP via the Kubernetes API (MetalLB LoadBalancer service) and patches `user_config.yaml` with a static NAT external address on every boot
- `USER_CONFIG_BASE64` env var for backup/restore of node identity and wallet keys
- Persistent storage for chain state and config

## Note on image

The SDL currently references a temporary test image (`ghcr.io/vpavlin/logos-blockchain-node:0.1.2-curl-3`) while [logos-blockchain/logos-blockchain#2911](https://github.com/logos-blockchain/logos-blockchain/pull/2911) — which adds `curl`, `jq`, and `yq` to the official image — is under review. Once merged and a new release is tagged the image reference will be updated to the official one.

## Test plan

- [x] Deployed on Akash, node synced to the network with 67+ peers
- [x] Leased IP auto-detected and patched into `user_config.yaml` as static NAT address
- [x] Node persists state across pod restarts via persistent volume
- [x] `USER_CONFIG_BASE64` restore flow verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)