### PR TITLE
docs: fix stale akash.network/docs links to current structure

### DIFF
--- a/Redash/README.md
+++ b/Redash/README.md
@@ -10,7 +10,7 @@ The original repo is here: https://github.com/getredash
   
 ### Akash Console DeploySet Up
 
-The provided deploy.yaml uses [IP leases](https://akash.network/docs/network-features/ip-leases) and [persistent storage](https://akash.network/docs/network-features/persistent-storage). Remove one or both of these features if you are not receiving bids.
+The provided deploy.yaml uses [IP leases](https://akash.network/docs/learn/core-concepts/ip-leases/) and [persistent storage](https://akash.network/docs/learn/core-concepts/persistent-storage/). Remove one or both of these features if you are not receiving bids.
 
 After deploying, inside the shell of the deployment select "redash" and pass the following commands in order. 
 

--- a/Redash/Redash Queries/readme.md
+++ b/Redash/Redash Queries/readme.md
@@ -10,7 +10,7 @@ The original repo is here: https://github.com/getredash
   
 ### Akash Console DeploySet Up
 
-The provided deploy.yaml uses [IP leases](https://akash.network/docs/network-features/ip-leases) and [persistent storage](https://akash.network/docs/network-features/persistent-storage). Remove one or both of these features if you are not receiving bids.
+The provided deploy.yaml uses [IP leases](https://akash.network/docs/learn/core-concepts/ip-leases/) and [persistent storage](https://akash.network/docs/learn/core-concepts/persistent-storage/). Remove one or both of these features if you are not receiving bids.
 
 After deploying, inside the shell of the deployment select "redash" and pass the following commands in order. 
 

--- a/Thorchain-BEPSwap/README.md
+++ b/Thorchain-BEPSwap/README.md
@@ -153,7 +153,7 @@ docker push $IMAGE
 
 ## Create the Deployment
 
-Create a deployment configuration [thorchain.yaml](deploy.yaml) to deploy the `edouardl/thorchain-bepswap-web-ui` for [ThorChain BEPSwap Web UI](https://github.com/thorchain/bepswap-web-ui) Node JS app container using [SDL](https://akash.network/docs/getting-started/stack-definition-language):
+Create a deployment configuration [thorchain.yaml](deploy.yaml) to deploy the `edouardl/thorchain-bepswap-web-ui` for [ThorChain BEPSwap Web UI](https://github.com/thorchain/bepswap-web-ui) Node JS app container using [SDL](https://akash.network/docs/developers/deployment/akash-sdl/):
 
 ```sh
 cat > thorchain.yaml <<EOF
@@ -198,7 +198,7 @@ deployment:
 EOF>>
 ```
 
-You may use the sample deployment file as-is or modify it for your own needs as desscribed in our [SDL (Stack Definition Language](https://akash.network/docs/getting-started/stack-definition-language) documentation.
+You may use the sample deployment file as-is or modify it for your own needs as desscribed in our [SDL (Stack Definition Language](https://akash.network/docs/developers/deployment/akash-sdl/) documentation.
 
 {% hint style="warn" %}
 

--- a/pancake-swap/GUIDE.md
+++ b/pancake-swap/GUIDE.md
@@ -90,7 +90,7 @@ Please note the balance indicated is denominated in uAKT (AKT * 10^-6), in the a
 
 ## Create the Deployment
 
-Create a deployment configuration `deploy.yaml` to deploy the `yuravorobei/pancake-swap` for [Pancake Swap Interface](https://github.com/pancakeswap/pancake-swap-interface) Node JS app container using [SDL](https://akash.network/docs/getting-started/stack-definition-language):
+Create a deployment configuration `deploy.yaml` to deploy the `yuravorobei/pancake-swap` for [Pancake Swap Interface](https://github.com/pancakeswap/pancake-swap-interface) Node JS app container using [SDL](https://akash.network/docs/developers/deployment/akash-sdl/):
 
 ```sh
 cat > deploy.yaml <<EOF
@@ -139,7 +139,7 @@ Alternatively, you can use cURL to download:
 curl -s https://raw.githubusercontent.com/ovrclk/awesome-akash/master/pancake-swap/deploy.yaml > deploy.yaml
 ```
 
-You may use the sample deployment file as-is or modify it for your own needs as desscribed in our [SDL (Stack Definition Language](https://akash.network/docs/getting-started/stack-definition-language) documentation. 
+You may use the sample deployment file as-is or modify it for your own needs as desscribed in our [SDL (Stack Definition Language](https://akash.network/docs/developers/deployment/akash-sdl/) documentation. 
 
 {% hint style="warn" %}
 


### PR DESCRIPTION
## Summary
Fix stale `akash.network/docs/*` links in four deployment examples. The Akash docs site was restructured and these paths now 404; updated them to the current, live locations (each verified to return 200).

| Old (404) | New (200) |
|---|---|
| `/docs/getting-started/stack-definition-language` | `/docs/developers/deployment/akash-sdl/` |
| `/docs/network-features/ip-leases` | `/docs/learn/core-concepts/ip-leases/` |
| `/docs/network-features/persistent-storage` | `/docs/learn/core-concepts/persistent-storage/` |

Files: `Redash/README.md`, `Redash/Redash Queries/readme.md`, `pancake-swap/GUIDE.md`, `Thorchain-BEPSwap/README.md`.

Only Akash-owned doc links are touched; third-party links are left as-is.
