### PR TITLE
feat(ci): notify console to publish templates on push

### DIFF
--- a/.github/workflows/notify-console.yml
+++ b/.github/workflows/notify-console.yml
@@ -1,0 +1,30 @@
+name: Notify Console to publish templates
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint cross-repo token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.CONSOLE_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.CONSOLE_DISPATCH_APP_PRIVATE_KEY }}
+          owner: akash-network
+          repositories: console
+
+      - name: Dispatch to console
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          gh api repos/akash-network/console/dispatches \
+            -f event_type=awesome-akash-updated \
+            -F "client_payload[sha]=$HEAD_SHA"


### PR DESCRIPTION
## Why

Templates on Akash Console are built from this repo by the console workflow [`akash-templates-publisher.yml`](https://github.com/akash-network/console/blob/main/.github/workflows/akash-templates-publisher.yml), which today only runs on a daily cron and manual dispatch. A commit here waits up to ~24h to be republished.

A `push` in this repo cannot trigger a workflow in another repo directly, so this adds a workflow that POSTs a `repository_dispatch` event to console on every push to `master`, republishing templates within seconds.

Companion PR (adds the matching trigger on the console side): akash-network/console#3529

## What

Adds `.github/workflows/notify-console.yml`:
- Triggers on push to `master`.
- Mints a short-lived, org-owned GitHub App token scoped to `akash-network/console` (`actions/create-github-app-token`, SHA-pinned).
- Calls `POST /repos/akash-network/console/dispatches` with `event_type=awesome-akash-updated`.

### Required before this works

Configure repo secrets in this repo (Settings → Secrets and variables → Actions):
- `CONSOLE_DISPATCH_APP_ID`
- `CONSOLE_DISPATCH_APP_PRIVATE_KEY`

from an org GitHub App granted **Contents: read/write** on `akash-network/console`. The built-in `GITHUB_TOKEN` cannot dispatch cross-repo, which is why an App token is used.

> Alternative: a fine-grained PAT scoped to `akash-network/console` with `contents: write`, stored as a single secret, replacing the token step with `GH_TOKEN: ${{ secrets.CONSOLE_DISPATCH_TOKEN }}`. The App token is preferred because it is org-owned rather than tied to a personal account.

The console-side trigger only fires on its default branch, so console#3529 must merge first.